### PR TITLE
Add README.md with GitHub Pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# AI-Dashboard
+
+This single-page application (SPA) provides a unified dashboard for tracking development progress. It aggregates data from GitHub and correlates it with task statuses from Google Jules.
+
+## GitHub Pages
+The application is hosted on GitHub Pages: [https://chatelao.github.io/AI-Dashboard/](https://chatelao.github.io/AI-Dashboard/)
+
+## Features
+- **GitHub API Integration:** Fetches real-time data for issues and pull requests.
+- **Google Jules Integration:** Tracks internal task statuses for AI agents.
+- **Status Matching:** Displays Jules-specific statuses for GitHub issues assigned to Jules.
+
+For more details, see [Gemini.md](Gemini.md).


### PR DESCRIPTION
This PR adds a `README.md` file to the repository. The file provides a brief overview of the AI-Dashboard project, its core features, and a direct link to the application hosted on GitHub Pages.

Fixes #4

---
*PR created automatically by Jules for task [1733565878032437867](https://jules.google.com/task/1733565878032437867) started by @chatelao*