### PR TITLE
Modernize GitHub Pages Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -19,7 +25,7 @@ jobs:
       - name: Setup Node ⚙️
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -29,8 +35,18 @@ jobs:
           npm ci
           npm run build
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload artifact 📦
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: web/dist
-          branch: gh-pages
+          path: web/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The 404 error on the GitHub Pages site was likely caused by an issue with the legacy branch-based deployment method or incorrect repository settings. This PR modernizes the deployment workflow to use the official `actions/upload-pages-artifact` and `actions/deploy-pages` tools, which is the recommended approach for Vite-based SPAs on GitHub Pages. This change also updates the Node.js version and adds proper concurrency controls to ensure clean deployments.

Fixes #9

---
*PR created automatically by Jules for task [15392270947047535414](https://jules.google.com/task/15392270947047535414) started by @chatelao*