### PR TITLE
Show issues on dashboard with linked PR indicators

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -87,3 +87,31 @@ a:hover {
 .text-muted {
   color: #666;
 }
+
+.pr-indicator {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 12px;
+  padding: 2px 6px;
+  background-color: #2b2b2b;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #8957e5;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.pr-indicator:hover {
+  background-color: #383838;
+  border-color: #8957e5;
+  color: #a371f7;
+}
+
+.pr-indicator span[role="img"] {
+  margin-right: 4px;
+}
+
+.pr-number {
+  font-weight: 600;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,11 @@ interface GitHubIssue {
   title: string;
   state: string;
   html_url: string;
+  body?: string | null;
+  pull_request?: {
+    url: string;
+    html_url: string;
+  };
   assignee: {
     login: string;
   } | null;
@@ -14,6 +19,10 @@ interface GitHubIssue {
 
 interface IssueWithJulesStatus extends GitHubIssue {
   julesStatus?: string;
+  linkedPR?: {
+    number: number;
+    html_url: string;
+  };
 }
 
 function App() {
@@ -35,15 +44,34 @@ function App() {
           throw new Error('Failed to fetch issues from GitHub');
         }
         const data: GitHubIssue[] = await response.json();
+        const rawIssues = data.filter(item => !item.pull_request);
+        const rawPRs = data.filter(item => !!item.pull_request);
 
-        const processedIssues = data.map(issue => {
-          if (issue.assignee?.login === 'Jules' && issue.state === 'open') {
-            return {
-              ...issue,
-              julesStatus: getJulesStatus(issue.id)
-            };
+        const issueToPRMap = new Map<number, { number: number; html_url: string }>();
+        rawPRs.forEach(pr => {
+          if (pr.body) {
+            // Support multiple GitHub keywords: Fixes, Fixed, Fix, Closes, Closed, Close, Resolves, Resolved, Resolve
+            const pattern = /(?:Fixes|Fixed|Fix|Closes|Closed|Close|Resolves|Resolved|Resolve)\s+#(\d+)/gi;
+            let match;
+            while ((match = pattern.exec(pr.body)) !== null) {
+              const issueNumber = parseInt(match[1], 10);
+              issueToPRMap.set(issueNumber, {
+                number: pr.number,
+                html_url: pr.html_url
+              });
+            }
           }
-          return issue;
+        });
+
+        const processedIssues = rawIssues.map(issue => {
+          const updatedIssue: IssueWithJulesStatus = { ...issue };
+          if (issue.assignee?.login === 'Jules' && issue.state === 'open') {
+            updatedIssue.julesStatus = getJulesStatus(issue.id);
+          }
+          if (issueToPRMap.has(issue.number)) {
+            updatedIssue.linkedPR = issueToPRMap.get(issue.number);
+          }
+          return updatedIssue;
         });
 
         setIssues(processedIssues);
@@ -88,6 +116,18 @@ function App() {
                       <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
                         {issue.title}
                       </a>
+                      {issue.linkedPR && (
+                        <a
+                          href={issue.linkedPR.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="pr-indicator"
+                          title={`Linked PR #${issue.linkedPR.number}`}
+                        >
+                          <span role="img" aria-label="PR">🔗</span>
+                          <span className="pr-number">#{issue.linkedPR.number}</span>
+                        </a>
+                      )}
                     </td>
                     <td>
                       <span className={`badge state-${issue.state}`}>


### PR DESCRIPTION
This change refines the dashboard to focus on GitHub issues while still providing visibility into associated work. Pull requests are no longer shown as separate entries in the table. Instead, the application now scans pull request descriptions for linking keywords (like "Fixes #123") and displays a distinctive link indicator next to the corresponding issue title. This mimics the GitHub interface and provides a cleaner, more issue-centric view of project progress.

Fixes #11

---
*PR created automatically by Jules for task [7805624876592102010](https://jules.google.com/task/7805624876592102010) started by @chatelao*