### PR TITLE
Add repo name as prefix to titles

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web</title>
+    <title>AI-Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -113,7 +113,7 @@ function App() {
   return (
     <div className="dashboard">
       <header>
-        <h1>AI Development Dashboard</h1>
+        <h1>AI-Dashboard: AI Development Dashboard</h1>
         <p>Unified view of GitHub Issues and Google Jules Statuses</p>
       </header>
 
@@ -140,7 +140,7 @@ function App() {
                     <td>{issue.number}</td>
                     <td>
                       <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
-                        {issue.title}
+                        [AI-Dashboard] {issue.title}
                       </a>
                     </td>
                     <td>


### PR DESCRIPTION
This PR adds "AI-Dashboard" as a prefix to the main titles of the application to provide better context. Specifically, it updates the HTML <title>, the main <h1> header, and each item title in the issues table.

Fixes #25

---
*PR created automatically by Jules for task [7548722889940136009](https://jules.google.com/task/7548722889940136009) started by @chatelao*