### PR TITLE
Reduce title space in dashboard

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,7 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 1rem 2rem;
   text-align: center;
 }
 
@@ -10,7 +10,7 @@
 }
 
 header {
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 
 .status-message {
@@ -126,8 +126,8 @@ a:hover {
   }
 
   h1 {
-    font-size: 2rem;
-    margin: 1rem 0;
+    font-size: 1.5rem;
+    margin: 0.5rem 0;
   }
 
   header p {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -74,12 +74,12 @@ h2 {
 }
 
 h1 {
-  font-size: 56px;
+  font-size: 32px;
   letter-spacing: -1.68px;
-  margin: 32px 0;
+  margin: 16px 0;
   @media (max-width: 1024px) {
-    font-size: 36px;
-    margin: 20px 0;
+    font-size: 24px;
+    margin: 12px 0;
   }
 }
 h2 {


### PR DESCRIPTION
Reduced h1 font sizes and margins in both desktop and mobile views to maximize vertical real estate. Adjusted header margins and root padding for a more compact layout.

Fixes #24

---
*PR created automatically by Jules for task [9712949439334477238](https://jules.google.com/task/9712949439334477238) started by @chatelao*