### PR TITLE
Add repository management and Jules issue creation

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -20,6 +20,99 @@ header {
   text-align: left;
 }
 
+.controls-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-top: 1.5rem;
+  padding: 1rem;
+  background-color: #1a1a1a;
+  border-radius: 8px;
+  border: 1px solid #333;
+  align-items: center;
+}
+
+.repo-select-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.repo-select-group label {
+  font-size: 0.9rem;
+  color: #aaa;
+}
+
+.repo-select-group select {
+  padding: 6px 10px;
+  background-color: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+}
+
+.add-repo-input {
+  display: flex;
+  gap: 5px;
+}
+
+.add-repo-input input {
+  padding: 6px 10px;
+  background-color: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+  width: 120px;
+}
+
+.add-repo-input button {
+  padding: 6px 12px;
+  background-color: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+  cursor: pointer;
+}
+
+.add-repo-input button:hover {
+  background-color: #30363d;
+}
+
+.issue-create-group {
+  display: flex;
+  gap: 10px;
+  flex-grow: 1;
+}
+
+.issue-create-group input {
+  flex-grow: 1;
+  padding: 6px 12px;
+  background-color: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+}
+
+.issue-create-group button {
+  padding: 6px 16px;
+  background-color: #238636;
+  color: white;
+  border: 1px solid rgba(240, 246, 252, 0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.issue-create-group button:hover:not(:disabled) {
+  background-color: #2ea043;
+}
+
+.issue-create-group button:disabled {
+  background-color: #23863680;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .settings-toggle {
   background: none;
   border: 1px solid #333;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,24 @@ function App() {
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [showSettings, setShowSettings] = useState<boolean>(false);
 
+  const [repos, setRepos] = useState<string[]>(() => {
+    const saved = localStorage.getItem('recent_repos');
+    return saved ? JSON.parse(saved) : ['chatelao/AI-Dashboard'];
+  });
+  const [currentRepo, setCurrentRepo] = useState<string>(() => {
+    return localStorage.getItem('current_repo') || repos[0];
+  });
+  const [newIssueTitle, setNewIssueTitle] = useState<string>('');
+  const [newRepo, setNewRepo] = useState<string>('');
+
+  useEffect(() => {
+    localStorage.setItem('recent_repos', JSON.stringify(repos));
+  }, [repos]);
+
+  useEffect(() => {
+    localStorage.setItem('current_repo', currentRepo);
+  }, [currentRepo]);
+
   const getJulesStatus = (issueId: number) => {
     const statuses = ["Researching", "Coding", "Testing", "Completed"];
     // Deterministic mock status based on issue ID
@@ -62,6 +80,43 @@ function App() {
     setShowSettings(false);
   };
 
+  const handleAddRepo = () => {
+    if (newRepo && !repos.includes(newRepo)) {
+      setRepos([...repos, newRepo]);
+      setCurrentRepo(newRepo);
+      setNewRepo('');
+    }
+  };
+
+  const handleCreateIssue = async () => {
+    if (!newIssueTitle || !ghToken) return;
+
+    try {
+      const response = await fetch(`https://api.github.com/repos/${currentRepo}/issues`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `token ${ghToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: newIssueTitle,
+          labels: ['Jules']
+        })
+      });
+
+      if (response.ok) {
+        setNewIssueTitle('');
+        // Refresh issues
+        window.location.reload();
+      } else {
+        const errorData = await response.json();
+        setError(`Failed to create issue: ${errorData.message}`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unknown error occurred while creating the issue');
+    }
+  };
+
   useEffect(() => {
     const fetchIssues = async () => {
       try {
@@ -76,8 +131,8 @@ function App() {
         }
 
         const [issuesResponse, prsResponse] = await Promise.all([
-          fetch('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all', { headers }),
-          fetch('https://api.github.com/repos/chatelao/AI-Dashboard/pulls?state=all', { headers })
+          fetch(`https://api.github.com/repos/${currentRepo}/issues?state=all`, { headers }),
+          fetch(`https://api.github.com/repos/${currentRepo}/pulls?state=all`, { headers })
         ]);
 
         if (!issuesResponse.ok || !prsResponse.ok) {
@@ -100,7 +155,7 @@ function App() {
             if (pr) {
               try {
                 const checkRunsResponse = await fetch(
-                  `https://api.github.com/repos/chatelao/AI-Dashboard/commits/${pr.head.sha}/check-runs`,
+                  `https://api.github.com/repos/${currentRepo}/commits/${pr.head.sha}/check-runs`,
                   { headers }
                 );
                 if (checkRunsResponse.ok) {
@@ -146,7 +201,7 @@ function App() {
     };
 
     fetchIssues();
-  }, [ghToken, julesToken]);
+  }, [ghToken, julesToken, currentRepo]);
 
   return (
     <div className="dashboard">
@@ -163,6 +218,47 @@ function App() {
           >
             ⚙️
           </button>
+        </div>
+
+        <div className="controls-section">
+          <div className="repo-select-group">
+            <label htmlFor="repo-select">Repository:</label>
+            <select
+              id="repo-select"
+              value={currentRepo}
+              onChange={(e) => setCurrentRepo(e.target.value)}
+            >
+              {repos.map(repo => (
+                <option key={repo} value={repo}>{repo}</option>
+              ))}
+            </select>
+            <div className="add-repo-input">
+              <input
+                type="text"
+                placeholder="owner/repo"
+                value={newRepo}
+                onChange={(e) => setNewRepo(e.target.value)}
+              />
+              <button onClick={handleAddRepo}>Add</button>
+            </div>
+          </div>
+
+          <div className="issue-create-group">
+            <input
+              type="text"
+              placeholder="New issue title..."
+              value={newIssueTitle}
+              onChange={(e) => setNewIssueTitle(e.target.value)}
+              disabled={!ghToken}
+            />
+            <button
+              onClick={handleCreateIssue}
+              disabled={!ghToken || !newIssueTitle}
+              title={!ghToken ? 'GitHub token required' : ''}
+            >
+              Create Issue (Jules)
+            </button>
+          </div>
         </div>
       </header>
 
@@ -220,7 +316,7 @@ function App() {
                     <td>{issue.number}</td>
                     <td>
                       <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
-                        [AI-Dashboard] {issue.title}
+                        [{currentRepo.split('/').pop()}] {issue.title}
                       </a>
                     </td>
                     <td>


### PR DESCRIPTION
This PR adds a repository management system to the AI-Dashboard, allowing users to switch between different GitHub repositories and add new ones to their recently used list. Additionally, it introduces a quick issue creation tool that automatically applies the 'Jules' label to new issues. The UI has been updated with a new controls section in the header, and repository settings are persisted in the browser's local storage.

Fixes #40

---
*PR created automatically by Jules for task [6759788149690984618](https://jules.google.com/task/6759788149690984618) started by @chatelao*