### PR TITLE
Add Status Filtering and Pagination Controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -132,6 +132,45 @@ header {
   color: #ff4d4d;
 }
 
+.controls-container {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background-color: #1a1a1a;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.control-group label {
+  font-size: 0.9rem;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.control-group select {
+  padding: 6px 10px;
+  background-color: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.control-group select:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
 .table-container {
   overflow-x: auto;
   background-color: #1a1a1a;
@@ -256,5 +295,15 @@ a:hover {
   .badge {
     padding: 2px 6px;
     font-size: 0.75rem;
+  }
+
+  .controls-container {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .control-group {
+    justify-content: space-between;
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,8 @@ function App() {
   const [draftGhToken, setDraftGhToken] = useState<string>(ghToken);
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [showSettings, setShowSettings] = useState<boolean>(false);
+  const [statusFilter, setStatusFilter] = useState<'all' | 'open'>('all');
+  const [pageSize, setPageSize] = useState<number>(10);
 
   const getJulesStatus = (issueId: number) => {
     const statuses = ["Researching", "Coding", "Testing", "Completed"];
@@ -75,20 +77,30 @@ function App() {
           // Future integration: headers['X-Jules-Token'] = julesToken;
         }
 
-        const [issuesResponse, prsResponse] = await Promise.all([
-          fetch('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all', { headers }),
-          fetch('https://api.github.com/repos/chatelao/AI-Dashboard/pulls?state=all', { headers })
+        // Fetch multiple pages to support up to 250 entries
+        const fetchAllPages = async (url: string) => {
+          let results: unknown[] = [];
+          for (let page = 1; page <= 3; page++) {
+            const response = await fetch(`${url}&per_page=100&page=${page}`, { headers });
+            if (!response.ok) break;
+            const data = await response.json() as unknown[];
+            if (!Array.isArray(data) || data.length === 0) break;
+            results = [...results, ...data];
+            if (data.length < 100) break;
+          }
+          return results;
+        };
+
+        const [issuesDataRaw, prsDataRaw] = await Promise.all([
+          fetchAllPages('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all'),
+          fetchAllPages('https://api.github.com/repos/chatelao/AI-Dashboard/pulls?state=all')
         ]);
 
-        if (!issuesResponse.ok || !prsResponse.ok) {
-          throw new Error('Failed to fetch data from GitHub');
-        }
-
-        const issuesData: GitHubIssue[] = await issuesResponse.json();
-        const prsData: { number: number; head: { sha: string } }[] = await prsResponse.json();
+        const issuesData = issuesDataRaw as GitHubIssue[];
+        const prsData = prsDataRaw as { number: number; head: { sha: string } }[];
         const prMap = new Map(prsData.map((pr) => [pr.number, pr]));
 
-        const processedIssues = await Promise.all(issuesData.map(async (issue) => {
+        const processedIssues = await Promise.all(issuesData.map(async (issue: GitHubIssue) => {
           const updatedIssue: IssueWithJulesStatus = { ...issue };
 
           if (issue.assignee?.login === 'Jules' && issue.state === 'open') {
@@ -202,8 +214,37 @@ function App() {
         {error && <p className="status-message error">Error: {error}</p>}
 
         {!loading && !error && (
-          <div className="table-container">
-            <table>
+          <>
+            <div className="controls-container">
+              <div className="control-group">
+                <label htmlFor="status-filter">Status:</label>
+                <select
+                  id="status-filter"
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value as 'all' | 'open')}
+                >
+                  <option value="all">All Statuses</option>
+                  <option value="open">Only Open</option>
+                </select>
+              </div>
+              <div className="control-group">
+                <label htmlFor="page-size">Show:</label>
+                <select
+                  id="page-size"
+                  value={pageSize}
+                  onChange={(e) => setPageSize(Number(e.target.value))}
+                >
+                  <option value="10">10 entries</option>
+                  <option value="20">20 entries</option>
+                  <option value="50">50 entries</option>
+                  <option value="100">100 entries</option>
+                  <option value="250">250 entries</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="table-container">
+              <table>
               <thead>
                 <tr>
                   <th>#</th>
@@ -215,7 +256,10 @@ function App() {
                 </tr>
               </thead>
               <tbody>
-                {issues.map(issue => (
+                {issues
+                  .filter(issue => statusFilter === 'all' || issue.state === 'open')
+                  .slice(0, pageSize)
+                  .map(issue => (
                   <tr key={issue.id}>
                     <td>{issue.number}</td>
                     <td>
@@ -227,6 +271,13 @@ function App() {
                       <span className={`badge state-${issue.state}`}>
                         {issue.state}
                       </span>
+                    </td>
+                    <td>
+                      {issue.assignee ? (
+                        <span>{issue.assignee.login}</span>
+                      ) : (
+                        <span className="text-muted">-</span>
+                      )}
                     </td>
                     <td>
                       {issue.prStatus ? (
@@ -266,6 +317,7 @@ function App() {
               </tbody>
             </table>
           </div>
+          </>
         )}
       </main>
     </div>


### PR DESCRIPTION
This change adds status filtering and pagination controls to the AI-Dashboard. Users can now filter the dashboard to show all issues or only open issues, and can choose the number of entries to display (10, 20, 50, 100, or 250). To support the 250-entry requirement, the data fetching logic has been updated to retrieve up to 3 pages (300 items) from the GitHub API. The table row rendering was also corrected to ensure all columns (including Assignee) are properly aligned with the headers. Styling was added to integrate these controls seamlessly into the existing dark-themed, responsive layout.

Fixes #41

---
*PR created automatically by Jules for task [7878647853636934355](https://jules.google.com/task/7878647853636934355) started by @chatelao*