### PR TITLE
Implement Google Jules status integration

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -247,7 +247,8 @@ a:hover {
   color: #58a6ff;
 }
 
-.pr-status-group {
+.pr-status-group,
+.jules-status-group {
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,10 +40,25 @@ function App() {
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [showSettings, setShowSettings] = useState<boolean>(false);
 
-  const getJulesStatus = (issueId: number) => {
-    const statuses = ["Researching", "Coding", "Testing", "Completed"];
-    // Deterministic mock status based on issue ID
-    return statuses[issueId % statuses.length];
+  const fetchJulesStatus = async (issueId: number, token: string): Promise<string | undefined> => {
+    try {
+      const response = await fetch(`${JULES_API_BASE_URL}/tasks/${issueId}/status`, {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      if (!response.ok) {
+        return undefined;
+      }
+      const data: unknown = await response.json();
+      if (data && typeof data === 'object' && 'status' in data && typeof data.status === 'string') {
+        return data.status;
+      }
+      return undefined;
+    } catch (err) {
+      console.error(`Failed to fetch Jules status for issue ${issueId}:`, err);
+      return undefined;
+    }
   };
 
   const handleSaveSettings = () => {
@@ -93,8 +108,8 @@ function App() {
         const processedItems = await Promise.all(issuesData.map(async (item) => {
           const updatedItem: IssueWithJulesStatus = { ...item };
 
-          if (item.assignee?.login === 'Jules' && item.state === 'open') {
-            updatedItem.julesStatus = getJulesStatus(item.id);
+          if (item.assignee?.login === 'Jules' && item.state === 'open' && julesToken) {
+            updatedItem.julesStatus = await fetchJulesStatus(item.id, julesToken);
           }
 
           if (item.pull_request) {
@@ -335,13 +350,26 @@ function App() {
                       </div>
                     </td>
                     <td>
-                      {issue.julesStatus ? (
-                        <span className={`badge jules-status-${issue.julesStatus.toLowerCase()}`}>
-                          {issue.julesStatus}
-                        </span>
-                      ) : (
-                        <span className="text-muted">-</span>
-                      )}
+                      <div className="jules-status-group">
+                        {issue.julesStatus ? (
+                          <span className={`badge jules-status-${issue.julesStatus.toLowerCase()}`}>
+                            {issue.julesStatus}
+                          </span>
+                        ) : (
+                          (!issue.linkedPRs || issue.linkedPRs.every(pr => !pr.julesStatus)) && (
+                            <span className="text-muted">-</span>
+                          )
+                        )}
+                        {issue.linkedPRs && issue.linkedPRs.map(pr => (
+                          pr.julesStatus && (
+                            <div key={pr.id} className="subtitle">
+                              <span className={`badge jules-status-${pr.julesStatus.toLowerCase()}`}>
+                                {pr.julesStatus}
+                              </span>
+                            </div>
+                          )
+                        ))}
+                      </div>
                     </td>
                   </tr>
                 ))}

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -95,4 +95,79 @@ test.describe('Dashboard Consolidation', () => {
     const rows = page.locator('tbody tr');
     await expect(rows).toHaveCount(2);
   });
+
+  test('should display Jules status for issues and linked PRs assigned to Jules', async ({ page }) => {
+    // Set mock jules_token
+    await page.addInitScript(() => {
+      window.localStorage.setItem('jules_token', 'mock-jules-token');
+    });
+
+    // Mock GitHub Issues API
+    await page.route('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 201,
+            number: 201,
+            title: 'Jules issue',
+            state: 'open',
+            html_url: 'https://github.com/chatelao/AI-Dashboard/issues/201',
+            body: 'Help me Jules',
+            assignee: { login: 'Jules' }
+          },
+          {
+            id: 202,
+            number: 202,
+            title: 'Jules PR',
+            state: 'open',
+            html_url: 'https://github.com/chatelao/AI-Dashboard/pull/202',
+            body: 'Fixes #201',
+            assignee: { login: 'Jules' },
+            pull_request: { url: '...', html_url: '...' }
+          }
+        ])
+      });
+    });
+
+    // Mock GitHub Pulls API
+    await page.route('https://api.github.com/repos/chatelao/AI-Dashboard/pulls?state=all', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { number: 202, head: { sha: 'sha202' } }
+        ])
+      });
+    });
+
+    // Mock Jules API for Issue 201
+    await page.route('https://jules.googleapis.com/v1/tasks/201/status', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'Coding' })
+      });
+    });
+
+    // Mock Jules API for PR 202
+    await page.route('https://jules.googleapis.com/v1/tasks/202/status', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'Researching' })
+      });
+    });
+
+    await page.goto('/');
+
+    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^201$/ }) });
+
+    // Verify Issue 201 status
+    await expect(issueRow.locator('td').nth(5)).toContainText('Coding');
+
+    // Verify Linked PR 202 status (as subtitle in Jules Status column)
+    await expect(issueRow.locator('td').nth(5).locator('.subtitle')).toContainText('Researching');
+  });
 });


### PR DESCRIPTION
This PR implements the integration with the Google Jules API to display real-time task statuses in the dashboard.

Key changes:
- **API Integration**: Implemented `fetchJulesStatus` helper in `App.tsx` to call `https://jules.googleapis.com/v1/tasks/{id}/status` using the provided Jules API token.
- **Data Consolidation**: Updated the issue processing logic to fetch Jules status for any issue or pull request assigned to "Jules".
- **UI Enhancement**: The "Jules Status" column now displays the status for the primary issue/PR in the row, as well as the statuses of any consolidated linked PRs as subtitles.
- **Styling**: Added `.jules-status-group` in `App.css` to manage the layout of multiple status badges in a single cell.
- **Testing**: Added a comprehensive Playwright test in `dashboard.spec.ts` that mocks both GitHub and Jules APIs to verify the end-to-end integration.

Verification:
- Integration tests passed (`npm run test`).
- Visual verification performed via Playwright screenshot, confirming correct rendering of multiple Jules status badges in the same row.

Fixes #51

---
*PR created automatically by Jules for task [18029716716460828024](https://jules.google.com/task/18029716716460828024) started by @chatelao*