### PR TITLE
Implement Multi-Repository Support in Dashboard

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -8,13 +8,14 @@ test('has title', async ({ page }) => {
 });
 
 test('dashboard loads issues and displays Jules status', async ({ page }) => {
-  // Set mock jules_token
+  // Set mock tokens
   await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
     window.localStorage.setItem('jules_token', 'mock-jules-token');
   });
 
-  // Mock GitHub Issues API
-  await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+  // Mock GitHub Global Issues API
+  await page.route('**/issues?state=all&filter=all*', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -26,6 +27,7 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
           state: 'open',
           html_url: 'https://github.com/chatelao/AI-Dashboard/issues/101',
           body: 'Help me Jules',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
           assignee: { login: 'Jules' },
           labels: []
         },
@@ -34,21 +36,13 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
           number: 102,
           title: 'Labeled issue',
           state: 'closed',
-          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/102',
+          html_url: 'https://github.com/chatelao/other-repo/issues/102',
           body: 'I have a label',
+          repository: { full_name: 'chatelao/other-repo' },
           assignee: null,
           labels: [{ name: 'Jules' }]
         }
       ])
-    });
-  });
-
-  // Mock GitHub Pulls API
-  await page.route('**/repos/chatelao/AI-Dashboard/pulls?state=all*', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([])
     });
   });
 
@@ -76,11 +70,13 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   const table = page.locator('table');
   await expect(table).toBeVisible();
 
-  // Verify Issue 101 status
+  // Verify Issue 101 status and repo name
   const row101 = page.locator('tr', { has: page.locator('td').filter({ hasText: /^101$/ }) });
+  await expect(row101.locator('td').nth(1)).toContainText('[AI-Dashboard]');
   await expect(row101.locator('td').nth(5)).toContainText('Coding');
 
-  // Verify Issue 102 status (closed but labeled Jules)
+  // Verify Issue 102 status and repo name
   const row102 = page.locator('tr', { has: page.locator('td').filter({ hasText: /^102$/ }) });
+  await expect(row102.locator('td').nth(1)).toContainText('[other-repo]');
   await expect(row102.locator('td').nth(5)).toContainText('Completed');
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,9 @@ interface GitHubIssue {
   state: string;
   html_url: string;
   body: string | null;
+  repository: {
+    full_name: string;
+  };
   assignee: {
     login: string;
   } | null;
@@ -95,18 +98,31 @@ function App() {
           // Future integration: headers['X-Jules-Token'] = julesToken;
         }
 
-        const [issuesResponse, prsResponse] = await Promise.all([
-          fetch('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all', { headers }),
-          fetch('https://api.github.com/repos/chatelao/AI-Dashboard/pulls?state=all', { headers })
-        ]);
-
-        if (!issuesResponse.ok || !prsResponse.ok) {
-          throw new Error('Failed to fetch data from GitHub');
+        let issuesData: GitHubIssue[] = [];
+        if (ghToken) {
+          // Fetch up to 3 pages (300 items) from global issues endpoint
+          for (let page = 1; page <= 3; page++) {
+            const response = await fetch(`https://api.github.com/issues?state=all&filter=all&per_page=100&page=${page}`, { headers });
+            if (!response.ok) {
+              if (page === 1) throw new Error('Failed to fetch data from GitHub');
+              break;
+            }
+            const data: GitHubIssue[] = await response.json();
+            if (data.length === 0) break;
+            issuesData = [...issuesData, ...data];
+            if (data.length < 100) break;
+          }
+        } else {
+          // Fallback to specific repo if no token
+          const response = await fetch('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all', { headers });
+          if (!response.ok) throw new Error('Failed to fetch data from GitHub');
+          const data: GitHubIssue[] = await response.json();
+          // Manually add repository info if missing
+          issuesData = data.map(item => ({
+            ...item,
+            repository: item.repository || { full_name: 'chatelao/AI-Dashboard' }
+          }));
         }
-
-        const issuesData: GitHubIssue[] = await issuesResponse.json();
-        const prsData: { number: number; head: { sha: string } }[] = await prsResponse.json();
-        const prMap = new Map(prsData.map((pr) => [pr.number, pr]));
 
         const processedItems = await Promise.all(issuesData.map(async (item) => {
           const updatedItem: IssueWithJulesStatus = { ...item };
@@ -119,11 +135,14 @@ function App() {
           }
 
           if (item.pull_request) {
-            const pr = prMap.get(item.number);
-            if (pr) {
-              try {
+            try {
+              // Fetch full PR details to get head.sha
+              const prResponse = await fetch(item.pull_request.url, { headers });
+              if (prResponse.ok) {
+                const prDetail = await prResponse.json();
+                const sha = prDetail.head.sha;
                 const checkRunsResponse = await fetch(
-                  `https://api.github.com/repos/chatelao/AI-Dashboard/commits/${pr.head.sha}/check-runs`,
+                  `https://api.github.com/repos/${item.repository.full_name}/commits/${sha}/check-runs`,
                   { headers }
                 );
                 if (checkRunsResponse.ok) {
@@ -151,9 +170,9 @@ function App() {
                     label: 'Create'
                   };
                 }
-              } catch (err) {
-                console.error(`Failed to fetch check runs for PR #${item.number}`, err);
               }
+            } catch (err) {
+              console.error(`Failed to fetch check runs for PR #${item.number}`, err);
             }
           }
 
@@ -167,23 +186,24 @@ function App() {
         const issuesOnly = processedItems.filter(item => !item.pull_request);
         const prsOnly = processedItems.filter(item => item.pull_request);
 
-        // Map issues by number for easy lookup
-        const issuesByNumber = new Map(issuesOnly.map(issue => [issue.number, issue]));
+        // Map issues by repo#number for easy lookup
+        const issuesByNumber = new Map(issuesOnly.map(issue => [`${issue.repository.full_name}#${issue.number}`, issue]));
 
-        // Link PRs to issues
+        // Link PRs to issues (within the same repo)
         prsOnly.forEach(pr => {
           if (pr.body) {
             const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
             let match;
             while ((match = regex.exec(pr.body)) !== null) {
               const issueNumber = parseInt(match[1], 10);
-              const issue = issuesByNumber.get(issueNumber);
+              const issueKey = `${pr.repository.full_name}#${issueNumber}`;
+              const issue = issuesByNumber.get(issueKey);
               if (issue) {
                 if (!issue.linkedPRs) {
                   issue.linkedPRs = [];
                 }
                 issue.linkedPRs.push(pr);
-                linkedPrNumbers.add(pr.number);
+                linkedPrNumbers.add(pr.id); // Use ID because number might not be unique across repos
               }
             }
           }
@@ -192,7 +212,7 @@ function App() {
         // Combine all issues and unlinked PRs
         issuesOnly.forEach(issue => finalIssues.push(issue));
         prsOnly.forEach(pr => {
-          if (!linkedPrNumbers.has(pr.number)) {
+          if (!linkedPrNumbers.has(pr.id)) {
             finalIssues.push(pr);
           }
         });
@@ -213,7 +233,7 @@ function App() {
       <header>
         <div className="header-content">
           <div>
-            <h1>AI-Dashboard: AI Development Dashboard</h1>
+            <h1>AI Development Dashboard</h1>
             <p>Unified view of GitHub Issues and Google Jules Statuses</p>
           </div>
           <button
@@ -281,7 +301,7 @@ function App() {
                     <td>
                       <div className="title-container">
                         <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
-                          [AI-Dashboard] {issue.title}
+                          [{issue.repository.full_name.split('/')[1]}] {issue.title}
                         </a>
                         {issue.linkedPRs && issue.linkedPRs.map(pr => (
                           <div key={pr.id} className="subtitle">


### PR DESCRIPTION
This PR expands the dashboard's scope from a single repository to all repositories associated with the user's GitHub account.

Key changes:
- Data Fetching: When a GitHub token is provided, the app now calls `https://api.github.com/issues?state=all&filter=all`. It also implements pagination for the first 3 pages (up to 300 items).
- Cross-Repo Linking: PRs are now linked to issues using a repository-scoped key (`repo#number`) to prevent incorrect linking across different repositories.
- UI Enhancements: The dashboard title is now "AI Development Dashboard", and each issue title is prefixed with its repository name (e.g., `[repo-name]`).
- Robustness: Added a fallback to the original repository for unauthenticated users and updated the PR status logic to fetch details from the PR's specific URL.
- Testing: Updated existing Playwright tests to mock multiple repositories and verified the changes with new assertions.

Fixes #58

---
*PR created automatically by Jules for task [978112094187773956](https://jules.google.com/task/978112094187773956) started by @chatelao*