### PR TITLE
Simplify dashboard title to AI-Dashboard

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -4,7 +4,7 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/AI Development Dashboard/);
+  await expect(page).toHaveTitle(/AI-Dashboard/);
 });
 
 test('dashboard loads issues and displays Jules status', async ({ page }) => {

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Development Dashboard</title>
+    <title>AI-Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -233,8 +233,7 @@ function App() {
       <header>
         <div className="header-content">
           <div>
-            <h1>AI Development Dashboard</h1>
-            <p>Unified view of GitHub Issues and Google Jules Statuses</p>
+            <h1>AI-Dashboard</h1>
           </div>
           <button
             className="settings-toggle"


### PR DESCRIPTION
Simplified the application title to "AI-Dashboard" across the UI, HTML metadata, and tests. Removed the descriptive subtitle as requested.

Fixes #72

---
*PR created automatically by Jules for task [2309572951715758029](https://jules.google.com/task/2309572951715758029) started by @chatelao*