### PR TITLE
Add issue filtering and pagination to the dashboard

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -132,6 +132,46 @@ header {
   color: #ff4d4d;
 }
 
+.filters-bar {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background-color: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 8px;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.filter-group label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #aaa;
+}
+
+.filter-group select {
+  padding: 6px 12px;
+  background-color: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #c9d1d9;
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.filter-group select:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
 .table-container {
   overflow-x: auto;
   background-color: #1a1a1a;
@@ -270,6 +310,17 @@ a:hover {
 
   header p {
     font-size: 0.9rem;
+  }
+
+  .filters-bar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+    padding: 0.75rem;
+  }
+
+  .filter-group {
+    justify-content: space-between;
   }
 
   .table-container {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,8 @@ function App() {
   const [draftGhToken, setDraftGhToken] = useState<string>(ghToken);
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [showSettings, setShowSettings] = useState<boolean>(false);
+  const [filterState, setFilterState] = useState<string>(localStorage.getItem('filter_state') || 'all');
+  const [pageSize, setPageSize] = useState<number>(parseInt(localStorage.getItem('page_size') || '50', 10));
 
   const fetchJulesStatus = async (issueId: number, token: string): Promise<{ status: string; url?: string } | undefined> => {
     try {
@@ -92,6 +94,16 @@ function App() {
     setShowSettings(false);
   };
 
+  const handleFilterStateChange = (newState: string) => {
+    setFilterState(newState);
+    localStorage.setItem('filter_state', newState);
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size);
+    localStorage.setItem('page_size', size.toString());
+  };
+
   useEffect(() => {
     const fetchIssues = async () => {
       try {
@@ -107,9 +119,9 @@ function App() {
 
         let issuesData: GitHubIssue[] = [];
         if (ghToken) {
-          // Fetch up to 3 pages (300 items) from global issues endpoint
-          for (let page = 1; page <= 3; page++) {
-            const response = await fetch(`https://api.github.com/issues?state=all&filter=all&per_page=100&page=${page}`, { headers });
+          // Fetch up to 5 pages (500 items) from global issues endpoint
+          for (let page = 1; page <= 5; page++) {
+            const response = await fetch(`https://api.github.com/issues?state=${filterState}&filter=all&per_page=100&page=${page}`, { headers });
             if (!response.ok) {
               if (page === 1) throw new Error('Failed to fetch data from GitHub');
               break;
@@ -121,7 +133,7 @@ function App() {
           }
         } else {
           // Fallback to specific repo if no token
-          const response = await fetch('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all', { headers });
+          const response = await fetch(`https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=${filterState}`, { headers });
           if (!response.ok) throw new Error('Failed to fetch data from GitHub');
           const data: GitHubIssue[] = await response.json();
           // Manually add repository info if missing
@@ -240,7 +252,7 @@ function App() {
     };
 
     fetchIssues();
-  }, [ghToken, julesToken]);
+  }, [ghToken, julesToken, filterState]);
 
   return (
     <div className="dashboard">
@@ -292,6 +304,36 @@ function App() {
       )}
 
       <main>
+        {!loading && !error && (
+          <div className="filters-bar">
+            <div className="filter-group">
+              <label htmlFor="state-filter">State:</label>
+              <select
+                id="state-filter"
+                value={filterState}
+                onChange={(e) => handleFilterStateChange(e.target.value)}
+              >
+                <option value="all">All</option>
+                <option value="open">Only Open</option>
+              </select>
+            </div>
+            <div className="filter-group">
+              <label htmlFor="page-size">Show:</label>
+              <select
+                id="page-size"
+                value={pageSize}
+                onChange={(e) => handlePageSizeChange(parseInt(e.target.value, 10))}
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+                <option value={100}>100</option>
+                <option value={250}>250</option>
+              </select>
+            </div>
+          </div>
+        )}
+
         {loading && <p className="status-message">Loading issues...</p>}
         {error && <p className="status-message error">Error: {error}</p>}
 
@@ -309,7 +351,7 @@ function App() {
                 </tr>
               </thead>
               <tbody>
-                {issues.map(issue => (
+                {issues.slice(0, pageSize).map(issue => (
                   <tr key={issue.id}>
                     <td>{issue.number}</td>
                     <td>

--- a/web/tests/filtering.spec.ts
+++ b/web/tests/filtering.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Filtering and Pagination', () => {
+  test('should filter by state (All vs Only Open)', async ({ page }) => {
+    // Mock GitHub Issues API for both "all" and "open" requests
+    await page.route('**/issues?state=all**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, number: 1, title: 'Open Issue', state: 'open', repository: { full_name: 'chatelao/AI-Dashboard' }, labels: [] },
+          { id: 2, number: 2, title: 'Closed Issue', state: 'closed', repository: { full_name: 'chatelao/AI-Dashboard' }, labels: [] }
+        ])
+      });
+    });
+
+    await page.route('**/issues?state=open**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, number: 1, title: 'Open Issue', state: 'open', repository: { full_name: 'chatelao/AI-Dashboard' }, labels: [] }
+        ])
+      });
+    });
+
+    await page.goto('/');
+
+    // Initially "all" is selected, should show 2 rows
+    const rowsAll = page.locator('tbody tr');
+    await expect(rowsAll).toHaveCount(2);
+
+    // Change filter to "Only Open"
+    await page.selectOption('#state-filter', 'open');
+
+    // Should now show 1 row
+    const rowsOpen = page.locator('tbody tr');
+    await expect(rowsOpen).toHaveCount(1);
+    await expect(rowsOpen).toContainText('Open Issue');
+  });
+
+  test('should limit results based on page size dropdown', async ({ page }) => {
+    // Generate 25 issues
+    const mockIssues = Array.from({ length: 25 }, (_, i) => ({
+      id: i + 1,
+      number: i + 1,
+      title: `Issue ${i + 1}`,
+      state: 'open',
+      repository: { full_name: 'chatelao/AI-Dashboard' },
+      labels: []
+    }));
+
+    await page.route('**/issues?state=all**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockIssues)
+      });
+    });
+
+    await page.goto('/');
+
+    // Default pageSize is 50, should show all 25 issues
+    const rowsDefault = page.locator('tbody tr');
+    await expect(rowsDefault).toHaveCount(25);
+
+    // Change pageSize to 10
+    await page.selectOption('#page-size', '10');
+
+    // Should now show 10 rows
+    const rows10 = page.locator('tbody tr');
+    await expect(rows10).toHaveCount(10);
+
+    // Change pageSize to 20
+    await page.selectOption('#page-size', '20');
+
+    // Should now show 20 rows
+    const rows20 = page.locator('tbody tr');
+    await expect(rows20).toHaveCount(20);
+  });
+});


### PR DESCRIPTION
Implemented issue filtering (All vs. Only Open) and pagination control (10, 20, 50, 100, 250 entries) on the dashboard. The filtering correctly triggers new data fetches from GitHub, while the page size control manages the local display limit. Both settings are persisted in localStorage for a better user experience. Comprehensive integration tests were added to ensure the reliability of these features.

Fixes #78

---
*PR created automatically by Jules for task [4446598118709186521](https://jules.google.com/task/4446598118709186521) started by @chatelao*