### PR TITLE
Remove header subtitle

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -5,6 +5,9 @@ test('has title', async ({ page }) => {
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/AI Development Dashboard/);
+
+  // Expect the description text to NOT be present.
+  await expect(page.locator('text=Unified view of GitHub Issues and Google Jules Statuses')).not.toBeVisible();
 });
 
 test('dashboard loads issues and displays Jules status', async ({ page }) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -248,7 +248,6 @@ function App() {
         <div className="header-content">
           <div>
             <h1>AI Development Dashboard</h1>
-            <p>Unified view of GitHub Issues and Google Jules Statuses</p>
           </div>
           <button
             className="settings-toggle"


### PR DESCRIPTION
Removed the description text 'Unified view of GitHub Issues and Google Jules Statuses' from the application header in App.tsx and updated the integration tests to ensure it is no longer displayed.

Fixes #81

---
*PR created automatically by Jules for task [3079734463580344510](https://jules.google.com/task/3079734463580344510) started by @chatelao*