### PR TITLE
Optimize UI for mobile phone screens

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -256,7 +256,8 @@ a:hover {
 
 @media (max-width: 768px) {
   #root {
-    padding: 1rem;
+    padding: 1rem 0.5rem;
+    text-align: left;
   }
 
   header {
@@ -272,13 +273,80 @@ a:hover {
     font-size: 0.9rem;
   }
 
-  .table-container {
-    padding: 0.5rem;
+  .settings-actions {
+    flex-direction: column;
   }
 
-  th, td {
-    padding: 8px 10px;
+  .settings-actions button {
+    width: 100%;
+  }
+
+  .table-container {
+    padding: 0;
+    background-color: transparent;
+    box-shadow: none;
+    overflow-x: hidden;
+  }
+
+  table {
+    min-width: auto;
+  }
+
+  table, thead, tbody, th, td, tr {
+    display: block;
+  }
+
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  tr {
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+    border: 1px solid #333;
+  }
+
+  td {
+    border: none;
+    border-bottom: 1px solid #333;
+    position: relative;
+    padding: 12px 10px 12px 40% !important;
+    text-align: right;
+    min-height: 2.5rem;
     font-size: 0.9rem;
+    word-break: break-word;
+  }
+
+  td:last-child {
+    border-bottom: none;
+  }
+
+  td::before {
+    content: attr(data-label);
+    position: absolute;
+    left: 10px;
+    width: 35%;
+    padding-right: 10px;
+    white-space: nowrap;
+    text-align: left;
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: #aaa;
+    text-transform: uppercase;
+  }
+
+  .title-container {
+    text-align: right;
+  }
+
+  .pr-status-group,
+  .jules-status-group {
+    align-items: flex-end;
   }
 
   .badge {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -311,8 +311,8 @@ function App() {
               <tbody>
                 {issues.map(issue => (
                   <tr key={issue.id}>
-                    <td>{issue.number}</td>
-                    <td>
+                    <td data-label="#">{issue.number}</td>
+                    <td data-label="Title">
                       <div className="title-container">
                         <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
                           [{issue.repository.full_name.split('/')[1]}] {issue.title}
@@ -326,12 +326,12 @@ function App() {
                         ))}
                       </div>
                     </td>
-                    <td>
+                    <td data-label="State">
                       <span className={`badge state-${issue.state}`}>
                         {issue.state}
                       </span>
                     </td>
-                    <td>
+                    <td data-label="Assignee">
                       {issue.assignee ? (
                         <span className="assignee-badge">
                           {issue.assignee.login}
@@ -340,7 +340,7 @@ function App() {
                         <span className="text-muted">-</span>
                       )}
                     </td>
-                    <td>
+                    <td data-label="PR">
                       <div className="pr-status-group">
                         {issue.prStatus && (
                           <div className="pr-status-container">
@@ -389,7 +389,7 @@ function App() {
                         )}
                       </div>
                     </td>
-                    <td>
+                    <td data-label="Jules Status">
                       <div className="jules-status-group">
                         {issue.julesStatus ? (
                           issue.julesUrl ? (


### PR DESCRIPTION
This PR optimizes the AI-Dashboard for mobile phone screens. The main change is the transformation of the dashboard table into a responsive card layout when viewed on devices with a width of 768px or less. This is achieved using CSS and `data-label` attributes on table cells, ensuring that data is readable without horizontal scrolling. Additionally, the Settings panel buttons are now stacked vertically on mobile for better accessibility. All changes were verified with mobile-viewport screenshots and by running the existing integration test suite.

Fixes #82

---
*PR created automatically by Jules for task [3009384276123835165](https://jules.google.com/task/3009384276123835165) started by @chatelao*