### PR TITLE
Remove # and Assignee columns

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -74,12 +74,12 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   await expect(table).toBeVisible();
 
   // Verify Issue 101 status and repo name
-  const row101 = page.locator('tr', { has: page.locator('td').filter({ hasText: /^101$/ }) });
-  await expect(row101.locator('td').nth(1)).toContainText('[AI-Dashboard]');
-  await expect(row101.locator('td').nth(5)).toContainText('Coding');
+  const row101 = page.locator('tr', { has: page.locator('td').filter({ hasText: /Jules issue/ }) });
+  await expect(row101.locator('td').nth(0)).toContainText('[AI-Dashboard]');
+  await expect(row101.locator('td').nth(3)).toContainText('Coding');
 
   // Verify Issue 102 status and repo name
-  const row102 = page.locator('tr', { has: page.locator('td').filter({ hasText: /^102$/ }) });
-  await expect(row102.locator('td').nth(1)).toContainText('[other-repo]');
-  await expect(row102.locator('td').nth(5)).toContainText('Completed');
+  const row102 = page.locator('tr', { has: page.locator('td').filter({ hasText: /Labeled issue/ }) });
+  await expect(row102.locator('td').nth(0)).toContainText('[other-repo]');
+  await expect(row102.locator('td').nth(3)).toContainText('Completed');
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -299,10 +299,8 @@ function App() {
             <table>
               <thead>
                 <tr>
-                  <th>#</th>
                   <th>Title</th>
                   <th>State</th>
-                  <th>Assignee</th>
                   <th>PR</th>
                   <th>Jules Status</th>
                 </tr>
@@ -310,7 +308,6 @@ function App() {
               <tbody>
                 {issues.map(issue => (
                   <tr key={issue.id}>
-                    <td data-label="#">{issue.number}</td>
                     <td data-label="Title">
                       <div className="title-container">
                         <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
@@ -329,15 +326,6 @@ function App() {
                       <span className={`badge state-${issue.state}`}>
                         {issue.state}
                       </span>
-                    </td>
-                    <td data-label="Assignee">
-                      {issue.assignee ? (
-                        <span className="assignee-badge">
-                          {issue.assignee.login}
-                        </span>
-                      ) : (
-                        <span className="text-muted">-</span>
-                      )}
                     </td>
                     <td data-label="PR">
                       <div className="pr-status-group">


### PR DESCRIPTION
This change removes the "#" and "Assignee" columns from the dashboard table in `web/src/App.tsx` to streamline the UI. The integration tests in `test/dashboard.spec.ts` have been updated to reflect the new 4-column structure and to use issue titles for row identification. All tests passed, and visual verification was performed.

Fixes #86

---
*PR created automatically by Jules for task [8248248302922058492](https://jules.google.com/task/8248248302922058492) started by @chatelao*