### PR TITLE
Hide closed issues by default and add filtering controls

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -78,8 +78,50 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   await expect(row101.locator('td').nth(0)).toContainText('[AI-Dashboard]');
   await expect(row101.locator('td').nth(3)).toContainText('Coding');
 
-  // Verify Issue 102 status and repo name
+  // Verify Issue 102 (closed) is NOT visible by default
   const row102 = page.locator('tr', { has: page.locator('td').filter({ hasText: /Labeled issue/ }) });
+  await expect(row102).not.toBeVisible();
+
+  // Switch filter to "all"
+  await page.selectOption('#status-filter', 'all');
+
+  // Verify Issue 102 status and repo name
   await expect(row102.locator('td').nth(0)).toContainText('[other-repo]');
   await expect(row102.locator('td').nth(3)).toContainText('Completed');
+});
+
+test('dashboard filters by page size', async ({ page }) => {
+  // Set mock tokens
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+  });
+
+  // Mock GitHub Global Issues API with 15 issues
+  await page.route('**/issues?state=all&filter=all*', async (route) => {
+    const issues = Array.from({ length: 15 }, (_, i) => ({
+      id: i + 1,
+      number: 100 + i,
+      title: `Issue ${i + 1}`,
+      state: 'open',
+      html_url: `https://github.com/chatelao/AI-Dashboard/issues/${100 + i}`,
+      repository: { full_name: 'chatelao/AI-Dashboard' },
+      labels: []
+    }));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(issues)
+    });
+  });
+
+  await page.goto('/');
+
+  // Default page size is 50, so all 15 should be visible
+  await expect(page.locator('tbody tr')).toHaveCount(15);
+
+  // Change page size to 10
+  await page.selectOption('#page-size', '10');
+
+  // Verify only 10 issues are visible
+  await expect(page.locator('tbody tr')).toHaveCount(10);
 });

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -132,6 +132,42 @@ header {
   color: #ff4d4d;
 }
 
+.filters-bar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 0 0.5rem;
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.filter-group label {
+  font-size: 0.9rem;
+  color: #aaa;
+  font-weight: 500;
+}
+
+.filter-group select {
+  padding: 6px 10px;
+  background-color: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  color: #c9d1d9;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.filter-group select:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
 .table-container {
   overflow-x: auto;
   background-color: #1a1a1a;
@@ -278,6 +314,22 @@ a:hover {
   }
 
   .settings-actions button {
+    width: 100%;
+  }
+
+  .filters-bar {
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .filter-group {
+    flex: 1;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .filter-group select {
     width: 100%;
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,8 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [ghToken, setGhToken] = useState<string>(localStorage.getItem('github_token') || '');
   const [julesToken, setJulesToken] = useState<string>(localStorage.getItem('jules_token') || '');
+  const [filterState, setFilterState] = useState<string>(localStorage.getItem('filter_state') || 'open');
+  const [pageSize, setPageSize] = useState<number>(parseInt(localStorage.getItem('page_size') || '50', 10));
   const [draftGhToken, setDraftGhToken] = useState<string>(ghToken);
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [showSettings, setShowSettings] = useState<boolean>(false);
@@ -90,6 +92,16 @@ function App() {
     setDraftGhToken('');
     setDraftJulesToken('');
     setShowSettings(false);
+  };
+
+  const handleFilterChange = (newState: string) => {
+    setFilterState(newState);
+    localStorage.setItem('filter_state', newState);
+  };
+
+  const handlePageSizeChange = (newSize: number) => {
+    setPageSize(newSize);
+    localStorage.setItem('page_size', newSize.toString());
   };
 
   useEffect(() => {
@@ -291,6 +303,34 @@ function App() {
       )}
 
       <main>
+        <div className="filters-bar">
+          <div className="filter-group">
+            <label htmlFor="status-filter">Status:</label>
+            <select
+              id="status-filter"
+              value={filterState}
+              onChange={(e) => handleFilterChange(e.target.value)}
+            >
+              <option value="all">All</option>
+              <option value="open">Open</option>
+            </select>
+          </div>
+          <div className="filter-group">
+            <label htmlFor="page-size">Show:</label>
+            <select
+              id="page-size"
+              value={pageSize}
+              onChange={(e) => handlePageSizeChange(parseInt(e.target.value, 10))}
+            >
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
+              <option value={100}>100</option>
+              <option value={250}>250</option>
+            </select>
+          </div>
+        </div>
+
         {loading && <p className="status-message">Loading issues...</p>}
         {error && <p className="status-message error">Error: {error}</p>}
 
@@ -306,7 +346,10 @@ function App() {
                 </tr>
               </thead>
               <tbody>
-                {issues.map(issue => (
+                {issues
+                  .filter(issue => filterState === 'all' || issue.state === filterState)
+                  .slice(0, pageSize)
+                  .map(issue => (
                   <tr key={issue.id}>
                     <td data-label="Title">
                       <div className="title-container">


### PR DESCRIPTION
This change implements a request to hide closed issues by default on the dashboard. I've added a status filter (All/Open) and a page size selector (10, 20, 50, 100, 250) to the dashboard. These settings are persisted in the browser's local storage. Existing tests were updated to account for the new default behavior, and a new test for page size filtering was added. All tests pass and the UI was verified with screenshots.

Fixes #89

---
*PR created automatically by Jules for task [484110294968987794](https://jules.google.com/task/484110294968987794) started by @chatelao*