### PR TITLE
Default dashboard to open issues filter

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -18,7 +18,7 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   });
 
   // Mock GitHub Issues API (now repo-specific)
-  await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+  await page.route('**/repos/chatelao/AI-Dashboard/issues?state=*', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -54,7 +54,7 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   await expect(table).toBeVisible();
 
   // Verify Issue 101 status and repo name
-  const row101 = page.locator('tr', { has: page.locator('td').filter({ hasText: /^101$/ }) });
-  await expect(row101.locator('td').nth(1)).toContainText('[AI-Dashboard]');
-  await expect(row101.locator('td').nth(5)).toContainText('Coding');
+  const row101 = page.locator('tr', { has: page.locator('td').filter({ hasText: /Jules issue/ }) });
+  await expect(row101.locator('td').nth(0)).toContainText('[AI-Dashboard]');
+  await expect(row101.locator('td').nth(3)).toContainText('Coding');
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,7 +52,7 @@ function App() {
     return saved ? JSON.parse(saved) : ['chatelao/AI-Dashboard'];
   });
   const [filterState, setFilterState] = useState<'all' | 'open'>(
-    (localStorage.getItem('filter_state') as 'all' | 'open') || 'all'
+    (localStorage.getItem('filter_state') as 'all' | 'open') || 'open'
   );
   const [pageSize, setPageSize] = useState<number>(
     parseInt(localStorage.getItem('page_size') || '50', 10)

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Dashboard Consolidation', () => {
   test('should consolidate PRs into issues as subtitles', async ({ page }) => {
     // Mock GitHub Issues API
-    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -92,7 +92,7 @@ test.describe('Dashboard Consolidation', () => {
     await page.goto('/');
 
     // Verify Issue 101 exists and has PR 102 as subtitle
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^101$/ }) });
+    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /Fix a bug/ }) });
     await expect(issueRow).toContainText('Fix a bug');
     await expect(issueRow.locator('.title-container .subtitle')).toContainText('PR #102: A linked PR');
 
@@ -100,7 +100,7 @@ test.describe('Dashboard Consolidation', () => {
     await expect(issueRow.locator('.pr-icon-green')).toBeVisible();
 
     // Verify PR 103 exists as a separate row (since it's not linked)
-    const prRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^103$/ }) });
+    const prRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /Unlinked PR/ }) });
     await expect(prRow).toContainText('Unlinked PR');
 
     // Verify total number of rows (should be 2: Issue 101 and PR 103)
@@ -115,7 +115,7 @@ test.describe('Dashboard Consolidation', () => {
     });
 
     // Mock GitHub Issues API
-    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -194,10 +194,10 @@ test.describe('Dashboard Consolidation', () => {
 
     await page.goto('/');
 
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^201$/ }) });
+    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /Jules issue/ }) });
 
     // Verify Issue 201 status and link
-    const julesStatusCell = issueRow.locator('td').nth(5);
+    const julesStatusCell = issueRow.locator('td').nth(3);
     await expect(julesStatusCell).toContainText('Coding');
     const issueLink = julesStatusCell.locator('a').first();
     await expect(issueLink).toHaveAttribute('href', 'https://jules.google.com/task/201');
@@ -216,7 +216,7 @@ test.describe('Dashboard Consolidation', () => {
     });
 
     // Mock GitHub Issues API
-    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -247,10 +247,10 @@ test.describe('Dashboard Consolidation', () => {
 
     await page.goto('/');
 
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^301$/ }) });
+    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /Lowercase Jules label/ }) });
 
     // Verify Issue 301 status
-    await expect(issueRow.locator('td').nth(5)).toContainText('Testing');
+    await expect(issueRow.locator('td').nth(3)).toContainText('Testing');
   });
 
   test('should display Jules status for items assigned to google-labs-jules[bot]', async ({ page }) => {
@@ -260,7 +260,7 @@ test.describe('Dashboard Consolidation', () => {
     });
 
     // Mock GitHub Issues API
-    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -291,9 +291,9 @@ test.describe('Dashboard Consolidation', () => {
 
     await page.goto('/');
 
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^401$/ }) });
+    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /Jules bot issue/ }) });
 
     // Verify Issue 401 status
-    await expect(issueRow.locator('td').nth(5)).toContainText('Completed');
+    await expect(issueRow.locator('td').nth(3)).toContainText('Completed');
   });
 });


### PR DESCRIPTION
This change updates the AI Development Dashboard to default to showing only open issues upon initial load. It also includes necessary updates to the Playwright test suite to align with the current 4-column table structure and ensure that tests are not tied to a specific default filter state.

Summary of changes:
1.  **App Logic:** In `web/src/App.tsx`, the `filterState` now defaults to `'open'` if no preference is saved in `localStorage`.
2.  **Test Flexibility:** Updated GitHub API route mocking in Playwright tests to use wildcards (`state=*`), allowing tests to pass regardless of the default filter.
3.  **Test Robustness:** Updated row locators in tests to find elements by their visible text (e.g., titles) rather than assuming a dedicated number column exists.
4.  **UI Alignment:** Corrected cell indices in test assertions to match the Title (0), State (1), PR (2), and Jules Status (3) columns.

Fixes #92

---
*PR created automatically by Jules for task [10633047693356434565](https://jules.google.com/task/10633047693356434565) started by @chatelao*