### PR TITLE
Rename 'Jules Status' column to 'Jules'

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -54,7 +54,7 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   await expect(table).toBeVisible();
 
   // Verify Issue 101 status and repo name
-  const row101 = page.locator('tr', { has: page.locator('td').filter({ hasText: /^101$/ }) });
-  await expect(row101.locator('td').nth(1)).toContainText('[AI-Dashboard]');
-  await expect(row101.locator('td').nth(5)).toContainText('Coding');
+  const row101 = page.locator('tr', { hasText: 'Jules issue' });
+  await expect(row101.locator('td').nth(0)).toContainText('[AI-Dashboard]');
+  await expect(row101.locator('td').nth(3)).toContainText('Coding');
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -375,7 +375,7 @@ function App() {
                   <th>Title</th>
                   <th>State</th>
                   <th>PR</th>
-                  <th>Jules Status</th>
+                  <th>Jules</th>
                 </tr>
               </thead>
               <tbody>
@@ -449,7 +449,7 @@ function App() {
                         )}
                       </div>
                     </td>
-                    <td data-label="Jules Status">
+                    <td data-label="Jules">
                       <div className="jules-status-group">
                         {issue.julesStatus ? (
                           issue.julesUrl ? (

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -92,16 +92,16 @@ test.describe('Dashboard Consolidation', () => {
     await page.goto('/');
 
     // Verify Issue 101 exists and has PR 102 as subtitle
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^101$/ }) });
-    await expect(issueRow).toContainText('Fix a bug');
+    const issueRow = page.locator('tr', { hasText: 'Fix a bug' });
+    await expect(issueRow).toBeVisible();
     await expect(issueRow.locator('.title-container .subtitle')).toContainText('PR #102: A linked PR');
 
     // Verify Issue 101's row has the green PR status icon (from linked PR 102)
     await expect(issueRow.locator('.pr-icon-green')).toBeVisible();
 
     // Verify PR 103 exists as a separate row (since it's not linked)
-    const prRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^103$/ }) });
-    await expect(prRow).toContainText('Unlinked PR');
+    const prRow = page.locator('tr', { hasText: 'Unlinked PR' });
+    await expect(prRow).toBeVisible();
 
     // Verify total number of rows (should be 2: Issue 101 and PR 103)
     const rows = page.locator('tbody tr');
@@ -194,15 +194,15 @@ test.describe('Dashboard Consolidation', () => {
 
     await page.goto('/');
 
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^201$/ }) });
+    const issueRow = page.locator('tr', { hasText: 'Jules issue' });
 
     // Verify Issue 201 status and link
-    const julesStatusCell = issueRow.locator('td').nth(5);
+    const julesStatusCell = issueRow.locator('td').nth(3);
     await expect(julesStatusCell).toContainText('Coding');
     const issueLink = julesStatusCell.locator('a').first();
     await expect(issueLink).toHaveAttribute('href', 'https://jules.google.com/task/201');
 
-    // Verify Linked PR 202 status and link (as subtitle in Jules Status column)
+    // Verify Linked PR 202 status and link (as subtitle in Jules column)
     const prSubtitle = julesStatusCell.locator('.subtitle');
     await expect(prSubtitle).toContainText('Researching');
     const prLink = prSubtitle.locator('a');
@@ -247,10 +247,10 @@ test.describe('Dashboard Consolidation', () => {
 
     await page.goto('/');
 
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^301$/ }) });
+    const issueRow = page.locator('tr', { hasText: 'Lowercase Jules label' });
 
     // Verify Issue 301 status
-    await expect(issueRow.locator('td').nth(5)).toContainText('Testing');
+    await expect(issueRow.locator('td').nth(3)).toContainText('Testing');
   });
 
   test('should display Jules status for items assigned to google-labs-jules[bot]', async ({ page }) => {
@@ -291,9 +291,9 @@ test.describe('Dashboard Consolidation', () => {
 
     await page.goto('/');
 
-    const issueRow = page.locator('tr', { has: page.locator('td').filter({ hasText: /^401$/ }) });
+    const issueRow = page.locator('tr', { hasText: 'Jules bot issue' });
 
     // Verify Issue 401 status
-    await expect(issueRow.locator('td').nth(5)).toContainText('Completed');
+    await expect(issueRow.locator('td').nth(3)).toContainText('Completed');
   });
 });


### PR DESCRIPTION
This change renames the "Jules Status" column in the AI Development Dashboard to "Jules" to make the interface cleaner. It also includes necessary updates to the Playwright integration tests, which were previously using incorrect column indices and row locators. All tests in both the root and `web/` directories now pass, and the visual change has been verified.

Fixes #95

---
*PR created automatically by Jules for task [14884157076599537248](https://jules.google.com/task/14884157076599537248) started by @chatelao*