### PR TITLE
Simplify UI: remove filter dropdowns and relocate Refresh button

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -32,19 +32,6 @@ h1 {
   gap: 0.5rem;
 }
 
-.settings-toggle {
-  background: none;
-  border: 1px solid #333;
-  border-radius: 4px;
-  padding: 8px;
-  cursor: pointer;
-  font-size: 1.2rem;
-  transition: background-color 0.2s;
-}
-
-.settings-toggle:hover {
-  background-color: #333;
-}
 
 .settings-panel {
   background-color: #1a1a1a;
@@ -135,45 +122,41 @@ h1 {
   background-color: #30363d;
 }
 
-.filters-bar {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
-  padding: 0.5rem 1rem;
-  background-color: #1a1a1a;
-  border-radius: 6px;
-  border: 1px solid #333;
-  flex-wrap: wrap;
-}
-
-.filter-group {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
-  color: #aaa;
-}
-
-.filter-group select {
-  padding: 4px 8px;
-  background-color: #0d1117;
-  border: 1px solid #30363d;
-  border-radius: 4px;
-  color: #c9d1d9;
-}
 
 .btn-refresh {
-  padding: 4px 12px;
+  padding: 8px 16px;
   background-color: #21262d;
   border: 1px solid #30363d;
   border-radius: 6px;
   color: #c9d1d9;
   cursor: pointer;
   font-size: 0.9rem;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
 }
 
 .btn-refresh:hover {
+  background-color: #30363d;
+}
+
+.settings-toggle {
+  background: none;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 0;
+  cursor: pointer;
+  font-size: 1.2rem;
+  transition: background-color 0.2s;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-toggle:hover {
   background-color: #30363d;
 }
 
@@ -335,21 +318,8 @@ a:hover {
     justify-content: flex-end;
   }
 
-  .filters-bar {
-    gap: 0.5rem;
-    padding: 0.5rem;
-  }
-
-  .filter-group {
-    flex-grow: 1;
-  }
-
-  .filter-group select {
-    width: 100%;
-  }
-
   .btn-refresh {
-    width: 100%;
+    width: auto;
   }
 
   header p {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,10 +54,10 @@ function App() {
     const saved = localStorage.getItem('gh_repos');
     return saved ? JSON.parse(saved) : ['chatelao/AI-Dashboard'];
   });
-  const [filterState, setFilterState] = useState<'all' | 'open'>(
+  const [filterState] = useState<'all' | 'open'>(
     (localStorage.getItem('filter_state') as 'all' | 'open') || 'all'
   );
-  const [pageSize, setPageSize] = useState<number>(
+  const [pageSize] = useState<number>(
     parseInt(localStorage.getItem('page_size') || '50', 10)
   );
   const [refreshTrigger, setRefreshTrigger] = useState<number>(0);
@@ -284,16 +284,6 @@ function App() {
     fetchIssues();
   }, [ghToken, julesToken, filterState, refreshTrigger, pageSize, repoHistory]);
 
-  const handleFilterChange = (state: 'all' | 'open') => {
-    setFilterState(state);
-    localStorage.setItem('filter_state', state);
-  };
-
-  const handlePageSizeChange = (size: number) => {
-    setPageSize(size);
-    localStorage.setItem('page_size', size.toString());
-  };
-
   return (
     <div className="dashboard">
       <header>
@@ -302,6 +292,9 @@ function App() {
             <h1>AI Development Dashboard</h1>
           </div>
           <div className="header-actions">
+            <button className="btn-refresh" onClick={() => setRefreshTrigger(prev => prev + 1)}>
+              Refresh
+            </button>
             <button
               className="settings-toggle"
               onClick={() => setShowSettings(!showSettings)}
@@ -356,29 +349,6 @@ function App() {
       )}
 
       <main>
-        <div className="filters-bar">
-          <div className="filter-group">
-            <label>Filter:</label>
-            <select value={filterState} onChange={(e) => handleFilterChange(e.target.value as 'all' | 'open')}>
-              <option value="all">All Issues</option>
-              <option value="open">Open Only</option>
-            </select>
-          </div>
-          <div className="filter-group">
-            <label>Show:</label>
-            <select value={pageSize} onChange={(e) => handlePageSizeChange(parseInt(e.target.value, 10))}>
-              <option value="10">10</option>
-              <option value="20">20</option>
-              <option value="50">50</option>
-              <option value="100">100</option>
-              <option value="250">250</option>
-            </select>
-          </div>
-          <button className="btn-refresh" onClick={() => setRefreshTrigger(prev => prev + 1)}>
-            Refresh
-          </button>
-        </div>
-
         {loading && <p className="status-message">Loading issues...</p>}
         {error && <p className="status-message error">Error: {error}</p>}
 


### PR DESCRIPTION
This PR simplifies the dashboard UI by removing the filtering controls (Issue state and Page size dropdowns) and relocating the Refresh button to the header.

Key changes:
- Removed the \`filters-bar\` div from \`App.tsx\`.
- Moved the "Refresh" button into the \`.header-actions\` container in the header.
- Cleaned up unused state update functions and CSS styles related to filtering.
- Standardized the height of header action buttons (Refresh and Settings) to 38px for visual consistency.
- Verified that the UI remains responsive and functional on both desktop and mobile viewports.

Fixes #111

---
*PR created automatically by Jules for task [6447356567078511517](https://jules.google.com/task/6447356567078511517) started by @chatelao*