### PR TITLE
Fix TypeScript deployment errors in App.tsx

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -187,10 +187,10 @@ function App() {
         const finalIssues: IssueWithJulesStatus[] = [];
         const linkedPrNumbers = new Set<number>();
 
-        const issuesOnly = issuesData.filter(item => !item.pull_request);
+        const issuesOnly = issuesData.filter(item => !item.pull_request) as IssueWithJulesStatus[];
         const prsOnly = issuesData.filter(item => item.pull_request);
 
-        const issuesByNumber = new Map(issuesOnly.map(issue => [`${issue.repository.full_name}#${issue.number}`, issue]));
+        const issuesByNumber = new Map<string, IssueWithJulesStatus>(issuesOnly.map(issue => [`${issue.repository.full_name}#${issue.number}`, issue]));
 
         prsOnly.forEach(pr => {
           if (pr.body) {


### PR DESCRIPTION
Fixed the TypeScript compilation errors in `web/src/App.tsx` that were causing the deployment to fail. The errors occurred because the code was attempting to access the `linkedPRs` property on objects typed as `GitHubIssue`, which does not have that property. I updated the types to use `IssueWithJulesStatus`, which correctly includes the `linkedPRs` property.

Verified the fix by running `npm run build` in the `web` directory and running the consolidated integration tests with Playwright, all of which passed.

Fixes #116

---
*PR created automatically by Jules for task [4849154229773903709](https://jules.google.com/task/4849154229773903709) started by @chatelao*