### PR TITLE
Allow managing tracked repositories via settings

### DIFF
--- a/test/settings.spec.ts
+++ b/test/settings.spec.ts
@@ -1,13 +1,14 @@
 import { test, expect } from '@playwright/test';
 
 test('can manage tracked repositories via settings', async ({ page }) => {
-  // Set mock token and initial repo
+  // Set mock token and initial state
   await page.addInitScript(() => {
     window.localStorage.setItem('github_token', 'mock-gh-token');
+    window.localStorage.setItem('gh_repos', JSON.stringify(['repo1/a']));
     (window as any).isTest = true;
   });
 
-  // Mock repo1
+  // Mock repo1 (default) issues
   await page.route('**/repos/repo1/a/issues?state=all*', async (route) => {
     await route.fulfill({
       status: 200,
@@ -28,7 +29,16 @@ test('can manage tracked repositories via settings', async ({ page }) => {
     });
   });
 
-  // Mock repo2
+  // Mock repo1 pulls
+  await page.route('**/repos/repo1/a/pulls?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
+  // Mock repo2 issues
   await page.route('**/repos/repo2/b/issues?state=all*', async (route) => {
     await route.fulfill({
       status: 200,
@@ -49,7 +59,19 @@ test('can manage tracked repositories via settings', async ({ page }) => {
     });
   });
 
+  // Mock repo2 pulls
+  await page.route('**/repos/repo2/b/pulls?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
   await page.goto('/');
+
+  // Wait for the first row to be visible
+  await expect(page.locator('text=[a] Issue from repo1')).toBeVisible();
 
   // Open settings
   await page.click('button[aria-label="Settings"]');
@@ -58,12 +80,14 @@ test('can manage tracked repositories via settings', async ({ page }) => {
   const repoInput = page.locator('#repo-history');
   await repoInput.fill('repo1/a, repo2/b');
 
-  // Save settings
+  // Save settings and wait for requests to complete
+  const savePromise = page.waitForResponse('**/repos/repo2/b/issues?state=all*');
   await page.click('button.btn-save');
+  await savePromise;
 
   // Verify both issues are present
   const rows = page.locator('tbody tr');
-  await expect(rows).toHaveCount(2);
+  await expect(rows).toHaveCount(2, { timeout: 10000 });
 
   await expect(page.locator('text=[a] Issue from repo1')).toBeVisible();
   await expect(page.locator('text=[b] Issue from repo2')).toBeVisible();

--- a/test/settings.spec.ts
+++ b/test/settings.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+test('can manage tracked repositories via settings', async ({ page }) => {
+  // Set mock token and initial repo
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+    (window as any).isTest = true;
+  });
+
+  // Mock repo1
+  await page.route('**/repos/repo1/a/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 1,
+          title: 'Issue from repo1',
+          state: 'open',
+          html_url: 'https://github.com/repo1/a/issues/1',
+          updated_at: '2023-10-01T12:00:00Z',
+          repository: { full_name: 'repo1/a' },
+          assignee: null,
+          labels: []
+        }
+      ])
+    });
+  });
+
+  // Mock repo2
+  await page.route('**/repos/repo2/b/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 2,
+          number: 2,
+          title: 'Issue from repo2',
+          state: 'open',
+          html_url: 'https://github.com/repo2/b/issues/2',
+          updated_at: '2023-10-02T12:00:00Z',
+          repository: { full_name: 'repo2/b' },
+          assignee: null,
+          labels: []
+        }
+      ])
+    });
+  });
+
+  await page.goto('/');
+
+  // Open settings
+  await page.click('button[aria-label="Settings"]');
+
+  // Add repo2 to tracked repositories
+  const repoInput = page.locator('#repo-history');
+  await repoInput.fill('repo1/a, repo2/b');
+
+  // Save settings
+  await page.click('button.btn-save');
+
+  // Verify both issues are present
+  const rows = page.locator('tbody tr');
+  await expect(rows).toHaveCount(2);
+
+  await expect(page.locator('text=[a] Issue from repo1')).toBeVisible();
+  await expect(page.locator('text=[b] Issue from repo2')).toBeVisible();
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,11 +52,21 @@ function App() {
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [draftJulesApiBase, setDraftJulesApiBase] = useState<string>(julesApiBase);
   const [showSettings, setShowSettings] = useState<boolean>(false);
+
   const [repoHistory, setRepoHistory] = useState<string[]>(() => {
     const saved = localStorage.getItem('gh_repos');
     return saved ? JSON.parse(saved) : ['chatelao/AI-Dashboard'];
   });
   const [draftRepoHistory, setDraftRepoHistory] = useState<string>(repoHistory.join(', '));
+
+  useEffect(() => {
+    if (showSettings) {
+      setDraftGhToken(ghToken);
+      setDraftJulesToken(julesToken);
+      setDraftJulesApiBase(julesApiBase);
+      setDraftRepoHistory(repoHistory.join(', '));
+    }
+  }, [showSettings, ghToken, julesToken, julesApiBase, repoHistory]);
   const [filterState] = useState<'all' | 'open'>(
     (localStorage.getItem('filter_state') as 'all' | 'open') || 'all'
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,10 +52,11 @@ function App() {
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [draftJulesApiBase, setDraftJulesApiBase] = useState<string>(julesApiBase);
   const [showSettings, setShowSettings] = useState<boolean>(false);
-  const [repoHistory] = useState<string[]>(() => {
+  const [repoHistory, setRepoHistory] = useState<string[]>(() => {
     const saved = localStorage.getItem('gh_repos');
     return saved ? JSON.parse(saved) : ['chatelao/AI-Dashboard'];
   });
+  const [draftRepoHistory, setDraftRepoHistory] = useState<string>(repoHistory.join(', '));
   const [filterState] = useState<'all' | 'open'>(
     (localStorage.getItem('filter_state') as 'all' | 'open') || 'all'
   );
@@ -125,12 +126,15 @@ function App() {
   };
 
   const handleSaveSettings = () => {
+    const newRepos = draftRepoHistory.split(',').map(r => r.trim()).filter(r => r.length > 0);
     localStorage.setItem('github_token', draftGhToken);
     localStorage.setItem('jules_token', draftJulesToken);
     localStorage.setItem('jules_api_base', draftJulesApiBase);
+    localStorage.setItem('gh_repos', JSON.stringify(newRepos));
     setGhToken(draftGhToken);
     setJulesToken(draftJulesToken);
     setJulesApiBase(draftJulesApiBase);
+    setRepoHistory(newRepos);
     setShowSettings(false);
     setRefreshTrigger(prev => prev + 1);
   };
@@ -139,12 +143,15 @@ function App() {
     localStorage.removeItem('github_token');
     localStorage.removeItem('jules_token');
     localStorage.removeItem('jules_api_base');
+    localStorage.removeItem('gh_repos');
     setGhToken('');
     setJulesToken('');
     setJulesApiBase(DEFAULT_JULES_API_BASE);
+    setRepoHistory(['chatelao/AI-Dashboard']);
     setDraftGhToken('');
     setDraftJulesToken('');
     setDraftJulesApiBase(DEFAULT_JULES_API_BASE);
+    setDraftRepoHistory('chatelao/AI-Dashboard');
     setShowSettings(false);
     setRefreshTrigger(prev => prev + 1);
   };
@@ -425,6 +432,16 @@ function App() {
             <small className="help-text">
               Use this to configure a CORS proxy if needed. See <a href="https://github.com/chatelao/AI-Dashboard/blob/main/CORS_PROXY.md" target="_blank" rel="noopener noreferrer">CORS_PROXY.md</a> for instructions.
             </small>
+          </div>
+          <div className="settings-group">
+            <label htmlFor="repo-history">Tracked Repositories (comma-separated):</label>
+            <input
+              id="repo-history"
+              type="text"
+              value={draftRepoHistory}
+              onChange={(e) => setDraftRepoHistory(e.target.value)}
+              placeholder="owner/repo, owner2/repo2"
+            />
           </div>
           <div className="settings-actions">
             <button className="btn-save" onClick={handleSaveSettings}>Save & Reload</button>


### PR DESCRIPTION
The dashboard now allows users to configure which repositories are tracked. A new "Tracked Repositories" field has been added to the settings panel, accepting a comma-separated list of "owner/repo" strings. This allows the dashboard to aggregate and display issues from multiple repositories as requested by the user.

Fixes #119

---
*PR created automatically by Jules for task [3421644061862050542](https://jules.google.com/task/3421644061862050542) started by @chatelao*