### PR TITLE
Fix Jules API 404 errors when using CORS proxy

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -23,6 +23,19 @@ If you have a standard webhosting account with PHP support, you can use this sim
  * Simple CORS Proxy for Jules API
  */
 
+// Polyfill for getallheaders if not available
+if (!function_exists('getallheaders')) {
+    function getallheaders() {
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+        }
+        return $headers;
+    }
+}
+
 // 1. Handle CORS Preflight
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Access-Control-Allow-Origin: *");
@@ -42,6 +55,12 @@ if (empty($path) && isset($_SERVER['REQUEST_URI'])) {
         $path = substr($requestUri, strlen($scriptName));
     }
 }
+
+// Auto-fix: Ensure path starts with /v1 if it looks like a task status request
+if (!empty($path) && strpos($path, '/v1/') !== 0 && strpos($path, '/tasks/') === 0) {
+    $path = '/v1' . $path;
+}
+
 $targetUrl = 'https://jules.googleapis.com' . $path;
 
 // 3. Forward the request using cURL
@@ -81,6 +100,16 @@ echo $response;
     - Open the dashboard **Settings** (⚙️ icon).
     - Update the **Jules API Base URL** to your proxy URL (e.g., `https://your-domain.com/proxy.php/v1`).
     - Click **Save & Reload**.
+
+---
+
+## Troubleshooting 404 Errors
+
+If you see 404 errors in the console while using the proxy, check the following:
+
+1.  **Missing `/v1`:** Ensure your Jules API Base URL in settings ends with `/v1`. The proxy script above has an auto-fix for this, but it's best to include it.
+2.  **Incorrect Path:** The dashboard appends `/tasks/{id}/status` to the Base URL. If your Base URL is `https://example.com/proxy.php`, the request becomes `https://example.com/proxy.php/tasks/...`.
+3.  **Proxy Configuration:** Ensure `PATH_INFO` is supported by your web server. If not, the fallback logic in the script should handle it, but you may need to check your server logs.
 
 ---
 

--- a/DEBUG_JULES.md
+++ b/DEBUG_JULES.md
@@ -28,7 +28,7 @@ The application logs its progress:
 
 **Common Error Indicators:**
 - **401 Unauthorized:** Your `jules_token` is invalid or expired.
-- **404 Not Found:** The Jules API does not have a task corresponding to that GitHub issue number.
+- **404 Not Found:** The Jules API does not have a task corresponding to that GitHub issue number. If using a **CORS Proxy**, this often means the `/v1` suffix is missing from the Base URL or the proxy script is not correctly forwarding the request.
 - **CORS Errors:** If you see "Access-Control-Allow-Origin" errors, the Jules API might not be configured to allow requests from your current domain (e.g., `localhost` or `github.io`). See [Resolving CORS Errors](#resolving-cors-errors) below.
 
 ## 4. Resolving CORS Errors

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -115,6 +115,9 @@ function App() {
       });
       console.log(`Jules API response status for issue ${issueId}: ${response.status}`);
       if (!response.ok) {
+        if (response.status === 404) {
+          console.warn(`Jules API returned 404 for issue ${issueId}. If using a proxy, ensure the Base URL includes '/v1' and the proxy is correctly configured.`);
+        }
         return undefined;
       }
       const data: unknown = await response.json();


### PR DESCRIPTION
The 404 errors from the proxy were caused by a missing `/v1` segment in the URL path. I've updated the suggested PHP proxy script in `CORS_PROXY.md` to automatically prepend `/v1` when appropriate, added a polyfill for better compatibility, and improved documentation in both `CORS_PROXY.md` and `DEBUG_JULES.md`. Additionally, I added a targeted console warning in the frontend to help users diagnose this specific configuration issue.

Fixes #124

---
*PR created automatically by Jules for task [5706546140800510875](https://jules.google.com/task/5706546140800510875) started by @chatelao*