### PR TITLE
Rename to AI-Dashboard and fix mobile header layout

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -1,6 +1,6 @@
 # Configuring a CORS Proxy for Jules API
 
-When running the AI Development Dashboard from a web browser (e.g., on GitHub Pages), you may encounter **CORS (Cross-Origin Resource Sharing)** errors when the browser attempts to fetch data from `https://jules.googleapis.com`. This happens because the Jules API does not explicitly allow requests from your dashboard's domain.
+When running the AI-Dashboard from a web browser (e.g., on GitHub Pages), you may encounter **CORS (Cross-Origin Resource Sharing)** errors when the browser attempts to fetch data from `https://jules.googleapis.com`. This happens because the Jules API does not explicitly allow requests from your dashboard's domain.
 
 ## Understanding the Error
 

--- a/DATA_FETCHING.md
+++ b/DATA_FETCHING.md
@@ -1,6 +1,6 @@
 # Data Fetching Documentation
 
-This document describes how the AI Development Dashboard collects and processes data from various sources.
+This document describes how the AI-Dashboard collects and processes data from various sources.
 
 ## Data Sources
 

--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -4,7 +4,7 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/AI Development Dashboard/);
+  await expect(page).toHaveTitle(/AI-Dashboard/);
 
   // Expect the description text to NOT be present.
   await expect(page.locator('text=Unified view of GitHub Issues and Google Jules Statuses')).not.toBeVisible();

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Development Dashboard</title>
+    <title>AI-Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -322,13 +322,12 @@ a:hover {
   }
 
   .header-content {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
     gap: 0.5rem;
   }
 
   .header-actions {
-    width: 100%;
     justify-content: flex-end;
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -390,7 +390,7 @@ function App() {
       <header>
         <div className="header-content">
           <div>
-            <h1>AI Development Dashboard</h1>
+            <h1>AI-Dashboard</h1>
           </div>
           <div className="header-actions">
             <button className="btn-refresh" onClick={() => setRefreshTrigger(prev => prev + 1)}>


### PR DESCRIPTION
This change renames the application from "AI Development Dashboard" to "AI-Dashboard" and adjusts the responsive CSS to keep the "Refresh" and "Settings" buttons on the same line as the title in mobile view.

Fixes #126

---
*PR created automatically by Jules for task [12056528514627926952](https://jules.google.com/task/12056528514627926952) started by @chatelao*