### PR TITLE
Auto-track all user repositories if tracked list is empty

### DIFF
--- a/test/auto_repos.spec.ts
+++ b/test/auto_repos.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+test('auto-tracks all repositories from user if tracked repositories list is empty', async ({ page }) => {
+  // Set mock token and initial state (empty repo list)
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+    window.localStorage.setItem('gh_repos', JSON.stringify([]));
+    (window as any).isTest = true;
+  });
+
+  // Mock /user/repos
+  await page.route('**/user/repos?sort=updated&per_page=100', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { full_name: 'user/repo-a' },
+        { full_name: 'user/repo-b' }
+      ])
+    });
+  });
+
+  // Mock repo-a issues
+  await page.route('**/repos/user/repo-a/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 1,
+          title: 'Issue A',
+          state: 'open',
+          html_url: 'https://github.com/user/repo-a/issues/1',
+          updated_at: '2023-10-01T12:00:00Z',
+          repository: { full_name: 'user/repo-a' },
+          assignee: null,
+          labels: []
+        }
+      ])
+    });
+  });
+
+  // Mock repo-a pulls
+  await page.route('**/repos/user/repo-a/pulls?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
+  // Mock repo-b issues
+  await page.route('**/repos/user/repo-b/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 2,
+          number: 2,
+          title: 'Issue B',
+          state: 'open',
+          html_url: 'https://github.com/user/repo-b/issues/2',
+          updated_at: '2023-10-02T12:00:00Z',
+          repository: { full_name: 'user/repo-b' },
+          assignee: null,
+          labels: []
+        }
+      ])
+    });
+  });
+
+  // Mock repo-b pulls
+  await page.route('**/repos/user/repo-b/pulls?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([])
+    });
+  });
+
+  await page.goto('/');
+
+  // Verify both issues are present
+  await expect(page.locator('text=[repo-a] Issue A')).toBeVisible();
+  await expect(page.locator('text=[repo-b] Issue B')).toBeVisible();
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -157,11 +157,11 @@ function App() {
     setGhToken('');
     setJulesToken('');
     setJulesApiBase(DEFAULT_JULES_API_BASE);
-    setRepoHistory(['chatelao/AI-Dashboard']);
+    setRepoHistory([]);
     setDraftGhToken('');
     setDraftJulesToken('');
     setDraftJulesApiBase(DEFAULT_JULES_API_BASE);
-    setDraftRepoHistory('chatelao/AI-Dashboard');
+    setDraftRepoHistory('');
     setShowSettings(false);
     setRefreshTrigger(prev => prev + 1);
   };
@@ -177,14 +177,27 @@ function App() {
           headers['Authorization'] = `token ${ghToken}`;
         }
 
+        let effectiveRepoList = [...repoHistory];
+        if (effectiveRepoList.length === 0 && ghToken) {
+          try {
+            const response = await fetch('https://api.github.com/user/repos?sort=updated&per_page=100', { headers });
+            if (response.ok) {
+              const repos: any[] = await response.json();
+              effectiveRepoList = repos.map(r => r.full_name);
+            }
+          } catch (err) {
+            console.error('Failed to fetch user repositories', err);
+          }
+        }
+
         const allReposResults = await Promise.all(
-          repoHistory.map(repo => fetchRawIssues(repo, filterState, headers))
+          effectiveRepoList.map(repo => fetchRawIssues(repo, filterState, headers))
         );
         const issuesData = allReposResults.flat();
 
         // Fetch PR metadata in bulk to get SHAs
         const prMetadataMap = new Map<string, string>();
-        await Promise.all(repoHistory.map(async (repo) => {
+        await Promise.all(effectiveRepoList.map(async (repo) => {
           try {
             const response = await fetch(`https://api.github.com/repos/${repo}/pulls?state=all&per_page=100`, { headers });
             if (response.ok) {
@@ -450,7 +463,7 @@ function App() {
               type="text"
               value={draftRepoHistory}
               onChange={(e) => setDraftRepoHistory(e.target.value)}
-              placeholder="owner/repo, owner2/repo2"
+              placeholder="owner/repo, owner2/repo2 (leave empty to track all your repos)"
             />
           </div>
           <div className="settings-actions">


### PR DESCRIPTION
This PR implements a feature that automatically tracks all repositories of the current user if the "Tracked Repositories" list in the settings is empty. 

Key changes:
- In `web/src/App.tsx`, the `fetchIssues` effect now checks if `repoHistory` is empty. If so, and if a GitHub token is provided, it fetches the user's repository list from `https://api.github.com/user/repos?sort=updated&per_page=100`.
- The `handleClearSettings` function was modified to reset `repoHistory` to an empty array instead of a hardcoded default repository.
- The placeholder for the "Tracked Repositories" input field was updated to inform users about this auto-tracking behavior.
- A new Playwright integration test (`test/auto_repos.spec.ts`) was added to verify the auto-tracking logic and ensure correctness.

All existing and new tests pass.

Fixes #125

---
*PR created automatically by Jules for task [16268078442560102706](https://jules.google.com/task/16268078442560102706) started by @chatelao*