### PR TITLE
Improve Jules API 404 troubleshooting and CORS proxy robustness

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -36,6 +36,22 @@ if (!function_exists('getallheaders')) {
     }
 }
 
+/**
+ * Get all headers, with extra robustness for the Authorization header
+ * which is often stripped by Apache/FastCGI.
+ */
+function getallheaders_robust() {
+    $headers = getallheaders();
+    if (!isset($headers['Authorization'])) {
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $headers['Authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
+        } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        }
+    }
+    return $headers;
+}
+
 // 1. Handle CORS Preflight
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Access-Control-Allow-Origin: *");
@@ -81,7 +97,7 @@ curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
 
 // Forward headers (excluding Host)
-$headers = getallheaders();
+$headers = getallheaders_robust();
 $curlHeaders = [];
 foreach ($headers as $key => $value) {
     if (strtolower($key) !== 'host') {

--- a/DEBUG_JULES.md
+++ b/DEBUG_JULES.md
@@ -28,7 +28,10 @@ The application logs its progress:
 
 **Common Error Indicators:**
 - **401 Unauthorized:** Your `jules_token` is invalid or expired.
-- **404 Not Found:** The Jules API does not have a task corresponding to that GitHub issue number.
+- **404 Not Found:** This can happen for several reasons:
+  - The Jules API does not have a task corresponding to that GitHub issue number.
+  - The **Jules API Base URL** in Settings is incorrect. It **must** include the `/v1` suffix (e.g., `https://jules.googleapis.com/v1`).
+  - Your CORS proxy is misconfigured and is not forwarding the `Authorization` header correctly. See [CORS_PROXY.md](CORS_PROXY.md) for a robust proxy script.
 - **CORS Errors:** If you see "Access-Control-Allow-Origin" errors, the Jules API might not be configured to allow requests from your current domain (e.g., `localhost` or `github.io`). See [Resolving CORS Errors](#resolving-cors-errors) below.
 
 ## 4. Resolving CORS Errors

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -121,6 +121,9 @@ function App() {
       });
       console.log(`Jules API response status for issue ${issueId}: ${response.status}`);
       if (!response.ok) {
+        if (response.status === 404) {
+          console.warn(`Jules API returned 404 for issue ${issueId}. Check your Jules API Base URL in Settings. It must end with /v1 (e.g., https://jules.googleapis.com/v1) and your proxy must forward the Authorization header.`);
+        }
         return undefined;
       }
       const data: unknown = await response.json();


### PR DESCRIPTION
This change addresses the issue where users encounter 404 errors when querying the Jules API, often due to a missing '/v1' suffix in the Base URL or the CORS proxy stripping the Authorization header. It provides better observability in the frontend and more robust documentation and sample code for the CORS proxy.

Fixes #137

---
*PR created automatically by Jules for task [17704191977778876636](https://jules.google.com/task/17704191977778876636) started by @chatelao*