### PR TITLE
Improve CORS Proxy and Jules API Troubleshooting

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -92,15 +92,33 @@ if (isset($_GET['url'])) {
 }
 
 // 3. Forward the request using cURL
+$headers = array_change_key_case(getallheaders_robust(), CASE_LOWER);
+
+// DIAGNOSTIC: Check for Authorization header if calling Jules API
+if (!isset($headers['authorization']) && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
+    header("Access-Control-Allow-Origin: *");
+    header("Content-Type: application/json");
+    http_response_code(401);
+    echo json_encode([
+        "error" => "Missing Authorization header",
+        "message" => "The proxy did not receive an Authorization header. If you are using Apache, you may need to add 'SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=$1' to your .htaccess file. See CORS_PROXY.md for details."
+    ]);
+    exit;
+}
+
 $ch = curl_init($targetUrl);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
 
-// Forward headers (excluding Host)
-$headers = getallheaders_robust();
+// Forward headers (excluding Host and browser-specific headers that might cause issues)
 $curlHeaders = [];
+$excludedHeaders = ['host', 'origin', 'referer'];
 foreach ($headers as $key => $value) {
-    if (strtolower($key) !== 'host') {
+    if (!in_array($key, $excludedHeaders) && strpos($key, 'sec-') !== 0) {
+        // Use original case if possible, but $headers is now lowercase keys
+        // For standard headers, title-case is usually fine if we wanted to be fancy,
+        // but most APIs (including Google) handle lowercase headers fine (HTTP/2 requires it anyway).
         $curlHeaders[] = "$key: $value";
     }
 }
@@ -111,6 +129,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     curl_setopt($ch, CURLOPT_POSTFIELDS, file_get_contents('php://input'));
 }
 
+// Capture response headers to forward Content-Type
+$responseContentType = 'application/json';
+curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($curl, $header) use (&$responseContentType) {
+    $len = strlen($header);
+    $parts = explode(':', $header, 2);
+    if (count($parts) === 2 && strtolower(trim($parts[0])) === 'content-type') {
+        $responseContentType = trim($parts[1]);
+    }
+    return $len;
+});
+
 $response = curl_exec($ch);
 $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 curl_close($ch);
@@ -119,7 +148,7 @@ curl_close($ch);
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
 header("Access-Control-Allow-Headers: *");
-header("Content-Type: application/json");
+header("Content-Type: $responseContentType");
 http_response_code($httpCode);
 echo $response;
 ```
@@ -130,6 +159,33 @@ echo $response;
     - If your server doesn't support paths after `.php`, use the `?url=` format: `https://your-domain.com/proxy.php?url=`
     - Otherwise, you can use the path format: `https://your-domain.com/proxy.php/v1`
     - Click **Save & Reload**.
+
+### Troubleshooting the Authorization Header
+
+On many Apache and PHP-FPM installations, the `Authorization` header is stripped before it reaches your PHP script. If the proxy returns a `401 Missing Authorization header` error despite you having configured it in the dashboard, try the following:
+
+#### Apache (.htaccess)
+
+Create or update the `.htaccess` file in the same directory as your `proxy.php`:
+
+```apache
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+</IfModule>
+
+# Alternative if the above doesn't work:
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+```
+
+#### Nginx (fastcgi_params)
+
+If you have access to the Nginx configuration, ensure the following line is present in your `location ~ \.php$` block:
+
+```nginx
+fastcgi_param HTTP_AUTHORIZATION $major_http_authorization;
+```
+(Or similar, depending on your Nginx/FPM version).
 
 ---
 

--- a/DEBUG_JULES.md
+++ b/DEBUG_JULES.md
@@ -27,12 +27,15 @@ The application logs its progress:
 - `Jules API response data for issue {number}: {data}`
 
 **Common Error Indicators:**
-- **401 Unauthorized:** Your `jules_token` is invalid or expired.
+- **401 Unauthorized:**
+  - Your `jules_token` is invalid or expired.
+  - **OR** your CORS proxy is not receiving the `Authorization` header. Many web servers (like Apache) strip this header by default. See [CORS_PROXY.md](CORS_PROXY.md#troubleshooting-the-authorization-header) for how to fix this using `.htaccess`.
 - **404 Not Found:** This can happen for several reasons:
   - The Jules API does not have a task corresponding to that GitHub issue number.
   - The **Jules API Base URL** in Settings is incorrect. It **must** include the `/v1` suffix (e.g., `https://jules.googleapis.com/v1`).
-  - Your CORS proxy is misconfigured and is not forwarding the `Authorization` header correctly. See [CORS_PROXY.md](CORS_PROXY.md) for a robust proxy script.
+  - Your CORS proxy is misconfigured. See [CORS_PROXY.md](CORS_PROXY.md) for a robust proxy script.
 - **CORS Errors:** If you see "Access-Control-Allow-Origin" errors, the Jules API might not be configured to allow requests from your current domain (e.g., `localhost` or `github.io`). See [Resolving CORS Errors](#resolving-cors-errors) below.
+- **SyntaxError: Unexpected token '<', "<html>..." is not valid JSON:** This usually means your proxy returned an HTML error page (like a 404 or 500 page from your web host) instead of the JSON response from the Jules API. Check the Network tab in your browser's Developer Tools to see the actual content returned by the proxy.
 
 ## 4. Resolving CORS Errors
 When running the dashboard in a browser, you may need a CORS proxy to access the Jules API.

--- a/reproduction/proxy.php
+++ b/reproduction/proxy.php
@@ -1,0 +1,26 @@
+<?php
+if (!function_exists('getallheaders')) {
+    function getallheaders() {
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+        }
+        return $headers;
+    }
+}
+function getallheaders_robust() {
+    $headers = getallheaders();
+    if (!isset($headers['Authorization'])) {
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $headers['Authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
+        } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        }
+    }
+    return $headers;
+}
+$headers = getallheaders_robust();
+header('Content-Type: application/json');
+echo json_encode(['headers' => $headers, 'server' => $_SERVER]);


### PR DESCRIPTION
Improved the robustness of the recommended CORS proxy script and documentation to address common failures when calling the Jules API.

Key improvements:
- **Header Normalization:** The proxy now uses case-insensitive header lookups to ensure the `Authorization` token is found regardless of how the web server passes it to PHP.
- **Header Filtering:** Browser-specific headers like `Origin`, `Referer`, and `Sec-*` are now removed before forwarding to Google's API, preventing potential security rejections.
- **Diagnostics:** Added a specific 401 error response when the proxy doesn't receive an `Authorization` header, including a tip about `.htaccess` configuration.
- **Documentation:** Added clear instructions for Apache (`.htaccess`) and Nginx to ensure headers are correctly passed to the PHP process.
- **Troubleshooting:** Enhanced `DEBUG_JULES.md` with explanations for common proxy-related errors.

Fixes #139

---
*PR created automatically by Jules for task [14906964378822562270](https://jules.google.com/task/14906964378822562270) started by @chatelao*