### PR TITLE
Implement X-Authorization fallback for Jules API calls

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -47,6 +47,10 @@ function getallheaders_robust() {
             $headers['Authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
         } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
             $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        } elseif (isset($headers['X-Authorization'])) {
+            $headers['Authorization'] = $headers['X-Authorization'];
+        } elseif (isset($_SERVER['HTTP_X_AUTHORIZATION'])) {
+            $headers['Authorization'] = $_SERVER['HTTP_X_AUTHORIZATION'];
         }
     }
     return $headers;
@@ -95,13 +99,13 @@ if (isset($_GET['url'])) {
 $headers = array_change_key_case(getallheaders_robust(), CASE_LOWER);
 
 // DIAGNOSTIC: Check for Authorization header if calling Jules API
-if (!isset($headers['authorization']) && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
+if (!isset($headers['authorization']) && !isset($headers['x-authorization']) && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
     header("Access-Control-Allow-Origin: *");
     header("Content-Type: application/json");
     http_response_code(401);
     echo json_encode([
         "error" => "Missing Authorization header",
-        "message" => "The proxy did not receive an Authorization header. If you are using Apache, you may need to add 'SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=$1' to your .htaccess file. See CORS_PROXY.md for details."
+        "message" => "The proxy did not receive an Authorization or X-Authorization header. If you are using Apache, you may need to add 'SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=$1' to your .htaccess file. See CORS_PROXY.md for details."
     ]);
     exit;
 }
@@ -162,7 +166,9 @@ echo $response;
 
 ### Troubleshooting the Authorization Header
 
-On many Apache and PHP-FPM installations, the `Authorization` header is stripped before it reaches your PHP script. If the proxy returns a `401 Missing Authorization header` error despite you having configured it in the dashboard, try the following:
+On many Apache and PHP-FPM installations, the `Authorization` header is stripped before it reaches your PHP script. The dashboard automatically sends an `X-Authorization` header as a fallback, which the provided proxy script is designed to handle.
+
+If the proxy still returns a `401 Missing Authorization header` error despite you having configured it in the dashboard, try the following:
 
 #### Apache (.htaccess)
 

--- a/DEBUG_JULES.md
+++ b/DEBUG_JULES.md
@@ -29,7 +29,7 @@ The application logs its progress:
 **Common Error Indicators:**
 - **401 Unauthorized:**
   - Your `jules_token` is invalid or expired.
-  - **OR** your CORS proxy is not receiving the `Authorization` header. Many web servers (like Apache) strip this header by default. See [CORS_PROXY.md](CORS_PROXY.md#troubleshooting-the-authorization-header) for how to fix this using `.htaccess`.
+  - **OR** your CORS proxy is not receiving the `Authorization` header. Many web servers (like Apache) strip this header by default. The dashboard automatically sends an `X-Authorization` header as a fallback. If you are using the proxy from [CORS_PROXY.md](CORS_PROXY.md), ensure you have updated it to the latest version that supports this fallback. See [CORS_PROXY.md](CORS_PROXY.md#troubleshooting-the-authorization-header) for more details.
 - **404 Not Found:** This can happen for several reasons:
   - The Jules API does not have a task corresponding to that GitHub issue number.
   - The **Jules API Base URL** in Settings is incorrect. It **must** include the `/v1` suffix (e.g., `https://jules.googleapis.com/v1`).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,7 +119,8 @@ function App() {
     try {
       const response = await fetch(url, {
         headers: {
-          'Authorization': `Bearer ${token}`
+          'Authorization': `Bearer ${token}`,
+          'X-Authorization': `Bearer ${token}`
         }
       });
       console.log(`Jules API response status for issue ${issueId}: ${response.status}`);


### PR DESCRIPTION
Implemented an `X-Authorization` header fallback for Jules API calls to resolve 401 Unauthorized errors caused by web servers (like Apache) stripping the standard `Authorization` header. The solution includes updates to the React frontend, the recommended PHP CORS proxy script, and troubleshooting documentation. Verified the fix with a Playwright script that confirms the proxy receives and processes the new header correctly.

Fixes #143

---
*PR created automatically by Jules for task [12285331224459222161](https://jules.google.com/task/12285331224459222161) started by @chatelao*