### PR TITLE
Add troubleshooting guide for Jules API 404 errors

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -98,14 +98,18 @@ if (isset($_GET['url'])) {
 // 3. Forward the request using cURL
 $headers = array_change_key_case(getallheaders_robust(), CASE_LOWER);
 
-// DIAGNOSTIC: Check for Authorization header if calling Jules API
-if (!isset($headers['authorization']) && !isset($headers['x-authorization']) && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
+// DIAGNOSTIC: Check for authentication headers if calling Jules API
+$hasAuth = isset($headers['authorization']) ||
+           isset($headers['x-authorization']) ||
+           isset($headers['x-goog-api-key']);
+
+if (!$hasAuth && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
     header("Access-Control-Allow-Origin: *");
     header("Content-Type: application/json");
     http_response_code(401);
     echo json_encode([
-        "error" => "Missing Authorization header",
-        "message" => "The proxy did not receive an Authorization or X-Authorization header. If you are using Apache, you may need to add 'SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=$1' to your .htaccess file. See CORS_PROXY.md for details."
+        "error" => "Missing Authentication header",
+        "message" => "The proxy did not receive an Authorization, X-Authorization, or X-Goog-Api-Key header. If you are using Apache, you may need to add 'SetEnvIf Authorization \"(.*)\" HTTP_AUTHORIZATION=$1' to your .htaccess file. See CORS_PROXY.md for details."
     ]);
     exit;
 }
@@ -164,11 +168,11 @@ echo $response;
     - Otherwise, you can use the path format: `https://your-domain.com/proxy.php/v1`
     - Click **Save & Reload**.
 
-### Troubleshooting the Authorization Header
+### Troubleshooting Authentication Headers
 
-On many Apache and PHP-FPM installations, the `Authorization` header is stripped before it reaches your PHP script. The dashboard automatically sends an `X-Authorization` header as a fallback, which the provided proxy script is designed to handle.
+On many Apache and PHP-FPM installations, the `Authorization` header is stripped before it reaches your PHP script. The dashboard automatically sends an `X-Authorization` header as a fallback. The proxy script also supports the `X-Goog-Api-Key` header for Jules API authentication.
 
-If the proxy still returns a `401 Missing Authorization header` error despite you having configured it in the dashboard, try the following:
+If the proxy returns a `401 Missing Authentication header` error despite you having configured it correctly, try the following:
 
 #### Apache (.htaccess)
 

--- a/DEBUG_JULES.md
+++ b/DEBUG_JULES.md
@@ -34,6 +34,7 @@ The application logs its progress:
   - The Jules API does not have a task corresponding to that GitHub issue number.
   - The **Jules API Base URL** in Settings is incorrect. It **must** include the `/v1` suffix (e.g., `https://jules.googleapis.com/v1`).
   - Your CORS proxy is misconfigured. See [CORS_PROXY.md](CORS_PROXY.md) for a robust proxy script.
+  - See [Deep Dive: Troubleshooting 404 Not Found](#deep-dive-troubleshooting-404-not-found) below for more details.
 - **CORS Errors:** If you see "Access-Control-Allow-Origin" errors, the Jules API might not be configured to allow requests from your current domain (e.g., `localhost` or `github.io`). See [Resolving CORS Errors](#resolving-cors-errors) below.
 - **SyntaxError: Unexpected token '<', "<html>..." is not valid JSON:** This usually means your proxy returned an HTML error page (like a 404 or 500 page from your web host) instead of the JSON response from the Jules API. Check the Network tab in your browser's Developer Tools to see the actual content returned by the proxy.
 
@@ -70,3 +71,54 @@ const result = await fetchJulesStatus(item.number, julesToken);
 ```
 
 Ensure the Jules task ID matches the GitHub issue number for the repository currently being viewed.
+
+## Deep Dive: Troubleshooting 404 Not Found
+
+If you encounter a `404 Not Found` error when fetching Jules status, especially when using a CORS proxy, use the following steps to isolate the cause.
+
+### 1. Analyze the Response Headers
+Look at the full HTTP response headers (available in the Network tab of your browser's Developer Tools).
+
+**Example of a problematic 404:**
+```http
+HTTP/1.1 404 Not Found
+Server: Apache
+Access-Control-Allow-Origin: *
+Content-Length: 0
+Content-Type: text/html;charset=UTF-8
+```
+
+**Key Indicators:**
+- **`Access-Control-Allow-Origin: *`**: If this header is present (and it's set by your proxy script), it means the request **successfully reached your proxy script**. The 404 is coming from either the proxy script's logic or the target Jules API.
+- **`Content-Length: 0`**: An empty body often suggests that the proxy script successfully executed but the `curl` call to the Jules API failed or returned an empty 404.
+- **`Content-Type: text/html`**: If your proxy script is designed to return `application/json` but you see `text/html`, it may mean the web server (Apache/Nginx) intercepted the request or encountered an error before the script could set the correct content type.
+- **`Server: Apache`**: This identifies the web server hosting your proxy.
+
+### 2. Verify the Target URL
+The most common cause for a 404 is an incorrect target URL. Check the `Fetching Jules status from: ...` log in the browser console.
+
+- **Correct:** `https://jules.googleapis.com/v1/tasks/123/status`
+- **Incorrect:** `https://jules.googleapis.com/tasks/123/status` (Missing `/v1`)
+- **Incorrect:** `https://jules.googleapis.com/v1/123/status` (Missing `/tasks`)
+
+If you are using the `?url=` parameter in your proxy:
+`https://your-proxy.com/proxy.php?url=https%3A%2F%2Fjules.googleapis.com%2Fv1%2Ftasks%2F123%2Fstatus`
+Ensure the target URL is fully encoded and correct.
+
+### 3. Test the Jules API Directly
+Use `curl` (as described in [Section 5](#5-test-api-with-curl)) to call the Jules API **without the proxy**.
+
+```bash
+curl -I -H "Authorization: Bearer YOUR_TOKEN" https://jules.googleapis.com/v1/tasks/YOUR_ISSUE_NUMBER/status
+```
+
+- If this returns **404**, then the issue is with the Jules API (e.g., the task doesn't exist for that number).
+- If this returns **200**, then the issue is with your **proxy configuration**.
+
+### 4. Debugging the Proxy Script
+If the Jules API is fine but the proxy returns 404:
+
+1. **Check PHP Error Logs:** Look at your webserver's error logs (`error_log`) for any PHP warnings or errors during the request.
+2. **Check cURL Support:** Ensure `php-curl` is installed and enabled on your server.
+3. **Verify Proxy Path Logic:** If you are NOT using `?url=`, your server must support `PATH_INFO`. If it doesn't, the proxy might be trying to reach an invalid URL. Switch to the `?url=` format in your Dashboard Settings to rule this out.
+4. **Inspect for Security Filters:** Some hosts use `ModSecurity` or similar tools that might block requests containing URLs in the query string, returning a 404 or 403. Check with your hosting provider if you suspect this.


### PR DESCRIPTION
Added a detailed troubleshooting section to `DEBUG_JULES.md` specifically addressing the `404 Not Found` error reported when using a CORS proxy with the Jules API. The new section provides a step-by-step diagnostic framework, including header analysis and direct API testing instructions.

Fixes #145

---
*PR created automatically by Jules for task [14641275235427887806](https://jules.google.com/task/14641275235427887806) started by @chatelao*