### PR TITLE
Hide secondary labels in mobile view

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -429,7 +429,7 @@ a:hover {
   }
 
   td::before {
-    display: block;
+    display: none;
     content: attr(data-label);
     font-size: 0.7rem;
     text-transform: uppercase;
@@ -437,10 +437,6 @@ a:hover {
     margin-bottom: 6px;
     font-weight: 600;
     letter-spacing: 0.05em;
-  }
-
-  td[data-label="Title"]::before {
-    display: none;
   }
 
   .title-container {


### PR DESCRIPTION
The task was to remove the secondary labels (State, PR, Jules) from the mobile view of the dashboard. 

I achieved this by:
1.  Modifying `web/src/App.css` within the `@media (max-width: 768px)` block.
2.  Changing `td::before` from `display: block` to `display: none`.
3.  Removing the specific `td[data-label="Title"]::before` rule as it is now covered by the global `td::before` rule.

I verified the change using a new Playwright test (since deleted) and by performing visual verification with a screenshot of the mobile view (iPhone 12 emulation). All existing tests also passed.

Fixes #148

---
*PR created automatically by Jules for task [5815262577527529183](https://jules.google.com/task/5815262577527529183) started by @chatelao*