### PR TITLE
Send X-Goog-Api-Key header to Jules API

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,7 +120,8 @@ function App() {
       const response = await fetch(url, {
         headers: {
           'Authorization': `Bearer ${token}`,
-          'X-Authorization': `Bearer ${token}`
+          'X-Authorization': `Bearer ${token}`,
+          'X-Goog-Api-Key': token
         }
       });
       console.log(`Jules API response status for issue ${issueId}: ${response.status}`);


### PR DESCRIPTION
This PR fixes an issue where the Google Jules API key (configured in the dashboard settings) was not being sent to the proxy/API using the `X-Goog-Api-Key` header.

Changes:
- Modified `web/src/App.tsx` to include the `X-Goog-Api-Key` header in the `fetchJulesStatus` function.
- Verified the fix using a Playwright test that captures and inspects outgoing request headers.
- Ensured compatibility with the CORS proxy script defined in `CORS_PROXY.md`, which explicitly checks for this header.

Fixes #147

---
*PR created automatically by Jules for task [2021159356095014242](https://jules.google.com/task/2021159356095014242) started by @chatelao*