### PR TITLE
Reduce repository tag font size

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -285,7 +285,7 @@ a:hover {
 }
 
 .repo-tag {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   background-color: rgba(139, 148, 158, 0.15);
   color: #8b949e;
   padding: 2px 6px;
@@ -419,6 +419,8 @@ a:hover {
     width: fit-content;
     margin-bottom: 6px;
     margin-right: 0;
+    font-size: 0.6rem;
+    padding: 1px 4px;
   }
 
   td[data-label="State"],


### PR DESCRIPTION
This change reduces the font size of the repository name tags in the dashboard.
- On desktop, the font size is reduced from 0.75rem to 0.7rem.
- On mobile (screens <= 768px), the font size is further reduced to 0.6rem and the padding is decreased to 1px 4px to save space in the card-based layout.
These changes were verified visually using Playwright screenshots and all existing tests passed.

Fixes #152

---
*PR created automatically by Jules for task [5267800172818643785](https://jules.google.com/task/5267800172818643785) started by @chatelao*