### PR TITLE
Improve Jules API proxy robustness and CORS handling

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -41,26 +41,31 @@ if (!function_exists('getallheaders')) {
  * which is often stripped by Apache/FastCGI.
  */
 function getallheaders_robust() {
-    $headers = getallheaders();
-    if (!isset($headers['Authorization'])) {
+    $headers = array_change_key_case(getallheaders(), CASE_LOWER);
+    if (!isset($headers['authorization'])) {
         if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
-            $headers['Authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
+            $headers['authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
         } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
-            $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
-        } elseif (isset($headers['X-Authorization'])) {
-            $headers['Authorization'] = $headers['X-Authorization'];
+            $headers['authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        } elseif (isset($headers['x-authorization'])) {
+            $headers['authorization'] = $headers['x-authorization'];
         } elseif (isset($_SERVER['HTTP_X_AUTHORIZATION'])) {
-            $headers['Authorization'] = $_SERVER['HTTP_X_AUTHORIZATION'];
+            $headers['authorization'] = $_SERVER['HTTP_X_AUTHORIZATION'];
         }
+    }
+    if (!isset($headers['x-goog-api-key']) && isset($_SERVER['HTTP_X_GOOG_API_KEY'])) {
+        $headers['x-goog-api-key'] = $_SERVER['HTTP_X_GOOG_API_KEY'];
     }
     return $headers;
 }
 
 // 1. Handle CORS Preflight
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '*';
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    header("Access-Control-Allow-Origin: *");
-    header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+    header("Access-Control-Allow-Origin: $origin");
+    header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
     header("Access-Control-Allow-Headers: *");
+    header("Access-Control-Allow-Credentials: true");
     exit;
 }
 
@@ -96,7 +101,7 @@ if (isset($_GET['url'])) {
 }
 
 // 3. Forward the request using cURL
-$headers = array_change_key_case(getallheaders_robust(), CASE_LOWER);
+$headers = getallheaders_robust();
 
 // DIAGNOSTIC: Check for authentication headers if calling Jules API
 $hasAuth = isset($headers['authorization']) ||
@@ -104,7 +109,8 @@ $hasAuth = isset($headers['authorization']) ||
            isset($headers['x-goog-api-key']);
 
 if (!$hasAuth && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
-    header("Access-Control-Allow-Origin: *");
+    header("Access-Control-Allow-Origin: $origin");
+    header("Access-Control-Allow-Credentials: true");
     header("Content-Type: application/json");
     http_response_code(401);
     echo json_encode([
@@ -124,10 +130,9 @@ $curlHeaders = [];
 $excludedHeaders = ['host', 'origin', 'referer'];
 foreach ($headers as $key => $value) {
     if (!in_array($key, $excludedHeaders) && strpos($key, 'sec-') !== 0) {
-        // Use original case if possible, but $headers is now lowercase keys
-        // For standard headers, title-case is usually fine if we wanted to be fancy,
-        // but most APIs (including Google) handle lowercase headers fine (HTTP/2 requires it anyway).
-        $curlHeaders[] = "$key: $value";
+        // Normalize common headers for better compatibility
+        $normalizedKey = str_replace(' ', '-', ucwords(str_replace('-', ' ', $key)));
+        $curlHeaders[] = "$normalizedKey: $value";
     }
 }
 curl_setopt($ch, CURLOPT_HTTPHEADER, $curlHeaders);
@@ -153,9 +158,10 @@ $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 curl_close($ch);
 
 // 4. Send Response with CORS headers
-header("Access-Control-Allow-Origin: *");
-header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+header("Access-Control-Allow-Origin: $origin");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
 header("Access-Control-Allow-Headers: *");
+header("Access-Control-Allow-Credentials: true");
 header("Content-Type: $responseContentType");
 http_response_code($httpCode);
 echo $response;

--- a/reproduction/proxy.php
+++ b/reproduction/proxy.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Reproduction Proxy for Jules API Debugging
+ */
+
 if (!function_exists('getallheaders')) {
     function getallheaders() {
         $headers = [];
@@ -10,17 +14,40 @@ if (!function_exists('getallheaders')) {
         return $headers;
     }
 }
+
 function getallheaders_robust() {
-    $headers = getallheaders();
-    if (!isset($headers['Authorization'])) {
+    $headers = array_change_key_case(getallheaders(), CASE_LOWER);
+    if (!isset($headers['authorization'])) {
         if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
-            $headers['Authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
+            $headers['authorization'] = $_SERVER['HTTP_AUTHORIZATION'];
         } elseif (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
-            $headers['Authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+            $headers['authorization'] = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        } elseif (isset($headers['x-authorization'])) {
+            $headers['authorization'] = $headers['x-authorization'];
+        } elseif (isset($_SERVER['HTTP_X_AUTHORIZATION'])) {
+            $headers['authorization'] = $_SERVER['HTTP_X_AUTHORIZATION'];
         }
+    }
+    if (!isset($headers['x-goog-api-key']) && isset($_SERVER['HTTP_X_GOOG_API_KEY'])) {
+        $headers['x-goog-api-key'] = $_SERVER['HTTP_X_GOOG_API_KEY'];
     }
     return $headers;
 }
+
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '*';
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    header("Access-Control-Allow-Origin: $origin");
+    header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
+    header("Access-Control-Allow-Headers: *");
+    header("Access-Control-Allow-Credentials: true");
+    exit;
+}
+
 $headers = getallheaders_robust();
+header("Access-Control-Allow-Origin: $origin");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
+header("Access-Control-Allow-Headers: *");
+header("Access-Control-Allow-Credentials: true");
 header('Content-Type: application/json');
+
 echo json_encode(['headers' => $headers, 'server' => $_SERVER]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,6 +119,7 @@ function App() {
     try {
       const response = await fetch(url, {
         headers: {
+          'Accept': 'application/json',
           'Authorization': `Bearer ${token}`,
           'X-Authorization': `Bearer ${token}`,
           'X-Goog-Api-Key': token


### PR DESCRIPTION
This PR improves the robustness of Jules API calls, especially when using a CORS proxy. 

Key changes:
1. **Client-side**: Added `Accept: application/json` to `fetchJulesStatus` to ensure the API returns the correct format.
2. **Proxy Documentation (`CORS_PROXY.md`)**: 
   - Implemented case-insensitive header detection using `array_change_key_case`.
   - Added dynamic `Origin` reflection instead of a wildcard `*` to support browser requests with `credentials: "include"`.
   - Added `Access-Control-Allow-Credentials: true` header.
   - Normalized header names (e.g., `Authorization`) when forwarding to the target API for better compatibility.
   - Improved detection of `X-Goog-Api-Key`.
3. **Reproduction Script**: Updated `reproduction/proxy.php` to match the improved logic.

These changes address common issues where proxies would strip the `Authorization` header or browsers would block the response due to CORS credential requirements.

Fixes #151

---
*PR created automatically by Jules for task [11344876601361732507](https://jules.google.com/task/11344876601361732507) started by @chatelao*