### PR TITLE
Migrate Jules API to v1alpha and update mocks

### DIFF
--- a/reproduction/proxy.php
+++ b/reproduction/proxy.php
@@ -50,4 +50,27 @@ header("Access-Control-Allow-Headers: *");
 header("Access-Control-Allow-Credentials: true");
 header('Content-Type: application/json');
 
+// Mock response based on the request URI for v1alpha/sessions
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (strpos($uri, 'v1alpha/sessions') !== false) {
+    $filter = $_GET['filter'] ?? '';
+    $issueNumber = 'unknown';
+    if (preg_match('/#(\d+)/', $filter, $matches)) {
+        $issueNumber = $matches[1];
+    }
+
+    echo json_encode([
+        'sessions' => [
+            [
+                'name' => 'sessions/mock-' . $issueNumber,
+                'state' => 'STATE_CODING',
+                'url' => 'https://jules.google.com/session/mock-' . $issueNumber,
+                'prompt' => "Fix issue #$issueNumber",
+                'createTime' => date('c')
+            ]
+        ]
+    ]);
+    exit;
+}
+
 echo json_encode(['headers' => $headers, 'server' => $_SERVER]);

--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -40,11 +40,19 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   });
 
   // Mock Jules API for Issue 101
-  await page.route('**/v1/tasks/101/status', async (route) => {
+  await page.route('**/v1alpha/sessions?filter=prompt%20:%20%22%23101%22', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ status: 'Coding' })
+      body: JSON.stringify({
+        sessions: [
+          {
+            name: 'sessions/123',
+            state: 'STATE_CODING',
+            url: 'https://jules.google.com/session/123'
+          }
+        ]
+      })
     });
   });
 
@@ -61,7 +69,7 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   // but since we want to be specific about the columns:
   const row101 = page.locator('tr', { has: page.locator('text=Jules issue') });
   await expect(row101.locator('td').nth(0)).toContainText('[AI-Dashboard]');
-  await expect(row101.locator('td').nth(3)).toContainText('Coding');
+  await expect(row101.locator('td').nth(3)).toContainText('coding');
 });
 
 test('dashboard aggregates issues from all repositories', async ({ page }) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,7 +42,7 @@ interface IssueWithJulesStatus extends GitHubIssue {
   actionLoading?: boolean;
 }
 
-const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1';
+const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1alpha';
 
 function App() {
   const [issues, setIssues] = useState<IssueWithJulesStatus[]>([]);
@@ -109,11 +109,14 @@ function App() {
 
   const fetchJulesStatus = async (issueId: number, token: string): Promise<{ status: string; url?: string } | undefined> => {
     let url;
+    // v1alpha uses /sessions with a filter or direct session access.
+    // We'll search for sessions related to the issue.
+    // For now, we assume Jules API is queried for a session associated with the issue.
     if (julesApiBase.includes('?url=')) {
-      const targetUrl = `https://jules.googleapis.com/v1/tasks/${issueId}/status`;
+      const targetUrl = `https://jules.googleapis.com/v1alpha/sessions?filter=prompt%20:%20%22%23${issueId}%22`;
       url = `${julesApiBase}${encodeURIComponent(targetUrl)}`;
     } else {
-      url = `${julesApiBase}/tasks/${issueId}/status`;
+      url = `${julesApiBase}/sessions?filter=prompt%20:%20%22%23${issueId}%22`;
     }
     console.log(`Fetching Jules status from: ${url}`);
     try {
@@ -128,20 +131,22 @@ function App() {
       console.log(`Jules API response status for issue ${issueId}: ${response.status}`);
       if (!response.ok) {
         if (response.status === 404) {
-          console.warn(`Jules API returned 404 for issue ${issueId}. Check your Jules API Base URL in Settings. It must end with /v1 (e.g., https://jules.googleapis.com/v1) and your proxy must forward the Authorization header.`);
+          console.warn(`Jules API returned 404 for issue ${issueId}. Check your Jules API Base URL in Settings. It must end with /v1alpha (e.g., https://jules.googleapis.com/v1alpha) and your proxy must forward the Authorization header.`);
         }
         return undefined;
       }
-      const data: unknown = await response.json();
+      const data: any = await response.json();
       console.log(`Jules API response data for issue ${issueId}:`, data);
-      if (data && typeof data === 'object' && 'status' in data && typeof data.status === 'string') {
-        const result: { status: string; url?: string } = { status: data.status };
-        if ('url' in data && typeof data.url === 'string') {
-          result.url = data.url;
-        } else if ('task_url' in data && typeof data.task_url === 'string') {
-          result.url = data.task_url;
+
+      // Look for the session in the list
+      if (data && data.sessions && Array.isArray(data.sessions) && data.sessions.length > 0) {
+        const session = data.sessions[0];
+        if (session.state) {
+          return {
+            status: session.state.replace('STATE_', '').replace(/_/g, ' ').toLowerCase(),
+            url: session.url
+          };
         }
-        return result;
       }
       return undefined;
     } catch (err) {
@@ -539,7 +544,7 @@ function App() {
               type="text"
               value={draftJulesApiBase}
               onChange={(e) => setDraftJulesApiBase(e.target.value)}
-              placeholder="https://jules.googleapis.com/v1"
+            placeholder="https://jules.googleapis.com/v1alpha"
             />
             <small className="help-text">
               Use this to configure a CORS proxy if needed. See <a href="https://github.com/chatelao/AI-Dashboard/blob/main/CORS_PROXY.md" target="_blank" rel="noopener noreferrer">CORS_PROXY.md</a> for instructions.


### PR DESCRIPTION
This change migrates the Jules API integration from the legacy `v1/tasks` endpoint to the `v1alpha/sessions` endpoint as defined in the `api-docs/openapi-jules.json` specification. 

Key changes include:
1.  **Frontend API Client**: Refactored `fetchJulesStatus` in `web/src/App.tsx` to use the `/sessions` endpoint with a filter on the `prompt` field (e.g., `filter=prompt : "#101"`). The response parsing now correctly handles the list of sessions and maps the `STATE_` enums to human-readable statuses.
2.  **Mocks & Testing**: Updated Playwright tests to reflect the new API structure.
3.  **Reproduction Tooling**: Updated the `reproduction/proxy.php` script to act as a mock server for the new endpoint, extracting the issue number from the filter to provide context-aware mock sessions.
4.  **UI Consistency**: Updated the default Jules API base URL and settings placeholders to point to `v1alpha`.

These changes ensure the dashboard remains compatible with the latest Jules API version and provides a robust testing environment.

Fixes #161

---
*PR created automatically by Jules for task [17210891950015557706](https://jules.google.com/task/17210891950015557706) started by @chatelao*