### PR TITLE
Fix Jules API integration and proxy routing

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -92,8 +92,10 @@ if (isset($_GET['url'])) {
         }
     }
 
-    // Auto-prepend /v1 if missing and not empty
-    if (!empty($path) && strpos($path, '/v1/') !== 0 && $path !== '/v1') {
+    // Auto-prepend /v1 if missing and not already v1 or v1alpha
+    if (!empty($path) &&
+        strpos($path, '/v1/') !== 0 && $path !== '/v1' &&
+        strpos($path, '/v1alpha/') !== 0 && $path !== '/v1alpha') {
         $path = '/v1' . $path;
     }
 
@@ -101,12 +103,12 @@ if (isset($_GET['url'])) {
 }
 
 // 3. Forward the request using cURL
-$headers = getallheaders_robust();
+$receivedHeaders = getallheaders_robust();
 
 // DIAGNOSTIC: Check for authentication headers if calling Jules API
-$hasAuth = isset($headers['authorization']) ||
-           isset($headers['x-authorization']) ||
-           isset($headers['x-goog-api-key']);
+$hasAuth = isset($receivedHeaders['authorization']) ||
+           isset($receivedHeaders['x-authorization']) ||
+           isset($receivedHeaders['x-goog-api-key']);
 
 if (!$hasAuth && strpos($targetUrl, 'https://jules.googleapis.com/') === 0) {
     header("Access-Control-Allow-Origin: $origin");
@@ -127,8 +129,8 @@ curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
 
 // Forward headers (excluding Host and browser-specific headers that might cause issues)
 $curlHeaders = [];
-$excludedHeaders = ['host', 'origin', 'referer'];
-foreach ($headers as $key => $value) {
+$excludedHeaders = ['host', 'origin', 'referer', 'x-authorization'];
+foreach ($receivedHeaders as $key => $value) {
     if (!in_array($key, $excludedHeaders) && strpos($key, 'sec-') !== 0) {
         // Normalize common headers for better compatibility
         $normalizedKey = str_replace(' ', '-', ucwords(str_replace('-', ' ', $key)));

--- a/reproduction/proxy.php
+++ b/reproduction/proxy.php
@@ -43,16 +43,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
-$headers = getallheaders_robust();
+// Prepare target URL logic (mirrored from CORS_PROXY.md)
+$path = $_SERVER['PATH_INFO'] ?? '';
+if (empty($path) && isset($_SERVER['REQUEST_URI'])) {
+    $scriptName = $_SERVER['SCRIPT_NAME'];
+    $requestUri = explode('?', $_SERVER['REQUEST_URI'])[0];
+    if (strpos($requestUri, $scriptName) === 0) {
+        $path = substr($requestUri, strlen($scriptName));
+    }
+}
+
+// Auto-prepend /v1 if missing and not already v1 or v1alpha
+if (!empty($path) &&
+    strpos($path, '/v1/') !== 0 && $path !== '/v1' &&
+    strpos($path, '/v1alpha/') !== 0 && $path !== '/v1alpha') {
+    $path = '/v1' . $path;
+}
+
+$targetUrl = 'https://jules.googleapis.com' . $path;
+
+$receivedHeaders = getallheaders_robust();
 header("Access-Control-Allow-Origin: $origin");
 header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
 header("Access-Control-Allow-Headers: *");
 header("Access-Control-Allow-Credentials: true");
 header('Content-Type: application/json');
 
-// Mock response based on the request URI for v1alpha/sessions
-$uri = $_SERVER['REQUEST_URI'] ?? '';
-if (strpos($uri, 'v1alpha/sessions') !== false) {
+// Mock response based on the targetUrl for v1alpha/sessions
+if (strpos($targetUrl, '/v1alpha/sessions') !== false) {
     $filter = $_GET['filter'] ?? '';
     $issueNumber = 'unknown';
     if (preg_match('/#(\d+)/', $filter, $matches)) {
@@ -73,4 +91,4 @@ if (strpos($uri, 'v1alpha/sessions') !== false) {
     exit;
 }
 
-echo json_encode(['headers' => $headers, 'server' => $_SERVER]);
+echo json_encode(['headers' => $receivedHeaders, 'targetUrl' => $targetUrl, 'server' => $_SERVER]);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -243,10 +243,14 @@ a:hover {
   color: white;
 }
 
-.jules-status-researching { background-color: #0366d6; color: white; }
-.jules-status-coding { background-color: #f1e05a; color: black; }
+.jules-status-researching, .jules-status-planning { background-color: #0366d6; color: white; }
+.jules-status-coding, .jules-status-in-progress { background-color: #f1e05a; color: black; }
 .jules-status-testing { background-color: #f66a0a; color: white; }
 .jules-status-completed { background-color: #28a745; color: white; }
+.jules-status-queued { background-color: #6a737d; color: white; }
+.jules-status-awaiting-plan-approval, .jules-status-awaiting-user-feedback { background-color: #d29922; color: white; }
+.jules-status-paused { background-color: #8b949e; color: white; }
+.jules-status-failed { background-color: #f85149; color: white; }
 
 .text-muted {
   color: #666;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,14 +120,19 @@ function App() {
     }
     console.log(`Fetching Jules status from: ${url}`);
     try {
-      const response = await fetch(url, {
-        headers: {
-          'Accept': 'application/json',
-          'Authorization': `Bearer ${token}`,
-          'X-Authorization': `Bearer ${token}`,
-          'X-Goog-Api-Key': token
-        }
-      });
+      const headers: HeadersInit = {
+        'Accept': 'application/json',
+      };
+
+      // Conditionally set auth headers to avoid conflicts
+      if (token.startsWith('AIza')) {
+        headers['X-Goog-Api-Key'] = token;
+      } else {
+        headers['Authorization'] = `Bearer ${token}`;
+        headers['X-Authorization'] = `Bearer ${token}`; // Fallback for proxy
+      }
+
+      const response = await fetch(url, { headers });
       console.log(`Jules API response status for issue ${issueId}: ${response.status}`);
       if (!response.ok) {
         if (response.status === 404) {
@@ -143,7 +148,7 @@ function App() {
         const session = data.sessions[0];
         if (session.state) {
           return {
-            status: session.state.replace('STATE_', '').replace(/_/g, ' ').toLowerCase(),
+            status: session.state.replace('STATE_', '').replace(/_/g, '-').toLowerCase(),
             url: session.url
           };
         }
@@ -707,13 +712,13 @@ function App() {
                         {issue.julesStatus ? (
                           issue.julesUrl ? (
                             <a href={issue.julesUrl} target="_blank" rel="noopener noreferrer">
-                              <span className={`badge jules-status-${issue.julesStatus.toLowerCase()}`}>
-                                {issue.julesStatus}
+                              <span className={`badge jules-status-${issue.julesStatus}`}>
+                                {issue.julesStatus.replace(/-/g, ' ')}
                               </span>
                             </a>
                           ) : (
-                            <span className={`badge jules-status-${issue.julesStatus.toLowerCase()}`}>
-                              {issue.julesStatus}
+                            <span className={`badge jules-status-${issue.julesStatus}`}>
+                              {issue.julesStatus.replace(/-/g, ' ')}
                             </span>
                           )
                         ) : (
@@ -734,13 +739,13 @@ function App() {
                             <div key={pr.id} className="subtitle">
                               {pr.julesUrl ? (
                                 <a href={pr.julesUrl} target="_blank" rel="noopener noreferrer">
-                                  <span className={`badge jules-status-${pr.julesStatus.toLowerCase()}`}>
-                                    {pr.julesStatus}
+                                  <span className={`badge jules-status-${pr.julesStatus}`}>
+                                    {pr.julesStatus.replace(/-/g, ' ')}
                                   </span>
                                 </a>
                               ) : (
-                                <span className={`badge jules-status-${pr.julesStatus.toLowerCase()}`}>
-                                  {pr.julesStatus}
+                                <span className={`badge jules-status-${pr.julesStatus}`}>
+                                  {pr.julesStatus.replace(/-/g, ' ')}
                                 </span>
                               )}
                             </div>


### PR DESCRIPTION
This PR fixes the Jules update failure by addressing two main issues:
1. **Proxy Routing Bug**: The PHP proxy was incorrectly prepending `/v1` to paths that already started with `/v1alpha`, leading to 404 errors.
2. **Authentication Header Conflicts**: The dashboard was sending multiple conflicting authentication headers simultaneously. We now conditionally send headers based on the token type (API Key vs OAuth).
Additionally, I improved the Jules status display by normalizing state strings for CSS classes and adding comprehensive styling for all session states.

Fixes #164

---
*PR created automatically by Jules for task [7722856347933053152](https://jules.google.com/task/7722856347933053152) started by @chatelao*