### PR TITLE
Download Jules API documentation

### DIFF
--- a/api-docs/rest.md
+++ b/api-docs/rest.md
@@ -1,0 +1,41 @@
+# Jules API
+
+Programmatically create and access your asynchronous coding tasks.
+
+- [REST Resource: v1alpha.sessions](https://developers.google.com/jules/api/reference/rest#v1alpha.sessions)
+- [REST Resource: v1alpha.sessions.activities](https://developers.google.com/jules/api/reference/rest#v1alpha.sessions.activities)
+- [REST Resource: v1alpha.sources](https://developers.google.com/jules/api/reference/rest#v1alpha.sources)
+
+## Service: jules.googleapis.com
+
+To call this service, we recommend that you use the Google-provided [client libraries](https://cloud.google.com/apis/docs/client-libraries-explained). If your application needs to use your own libraries to call this service, use the following information when you make the API requests.
+
+### Service endpoint
+
+A [service endpoint](https://cloud.google.com/apis/design/glossary#api_service_endpoint) is a base URL that specifies the network address of an API service. One service might have multiple service endpoints. This service has the following service endpoint and all URIs below are relative to this service endpoint:
+
+- `https://jules.googleapis.com`
+
+## REST Resource: [v1alpha.sessions](https://developers.google.com/jules/api/reference/rest/v1alpha/sessions)
+
+| Methods ||
+|---|---|
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/approvePlan` | `POST /v1alpha/{session=sessions/*}:approvePlan` Approves a plan in a session. |
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/create` | `POST /v1alpha/sessions` Creates a new session. |
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/get` | `GET /v1alpha/{name=sessions/*}` Gets a single session. |
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/list` | `GET /v1alpha/sessions` Lists all sessions. |
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/sendMessage` | `POST /v1alpha/{session=sessions/*}:sendMessage` Sends a message from the user to a session. |
+
+## REST Resource: [v1alpha.sessions.activities](https://developers.google.com/jules/api/reference/rest/v1alpha/sessions.activities)
+
+| Methods ||
+|---|---|
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions.activities/get` | `GET /v1alpha/{name=sessions/*/activities/*}` Gets a single activity. |
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sessions.activities/list` | `GET /v1alpha/{parent=sessions/*}/activities` Lists activities for a session. |
+
+## REST Resource: [v1alpha.sources](https://developers.google.com/jules/api/reference/rest/v1alpha/sources)
+
+| Methods ||
+|---|---|
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sources/get` | `GET /v1alpha/{name=sources/**}` Gets a single source. |
+| `https://developers.google.com/jules/api/reference/rest/v1alpha/sources/list` | `GET /v1alpha/sources` Lists sources. |


### PR DESCRIPTION
This change downloads the Jules API REST reference documentation from the provided URL and saves it as `api-docs/rest.md`. This provides a local copy of the API structure and methods for easier reference within the project. No functional code changes were made, and existing tests passed.

Fixes #168

---
*PR created automatically by Jules for task [17391078922244143554](https://jules.google.com/task/17391078922244143554) started by @chatelao*