### PR TITLE
Use singular Jules session endpoint and extract ID from comments

### DIFF
--- a/DATA_FETCHING.md
+++ b/DATA_FETCHING.md
@@ -21,7 +21,8 @@ For issues and pull requests identified as Jules tasks, the dashboard fetches th
 - **Identification:** An item is considered a Jules task if:
     - The assignee is `jules` or `google-labs-jules[bot]`.
     - It has a label named `Jules` (case-insensitive).
-- **Endpoint:** `https://jules.googleapis.com/v1/tasks/${issueNumber}/status`
+- **Session ID Retrieval:** The application fetches GitHub issue comments and searches for the latest "Jules is on it" comment from the Jules bot. It extracts the session ID from Markdown links (e.g., `jules.google.com/session/ID`), explicit labels (`task_id: ID`), or long numeric patterns.
+- **Endpoint:** `https://jules.googleapis.com/v1alpha/session/${sessionId}`
 - **Authentication:** Uses a Jules API Token stored in `localStorage` as `jules_token`. It is sent in the `Authorization` header using the `Bearer <TOKEN>` format.
 
 ## Data Processing

--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -39,19 +39,29 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
     });
   });
 
-  // Mock Jules API for Issue 101
-  await page.route('**/v1alpha/sessions?filter=prompt%20:%20%22%23101%22', async (route) => {
+  // Mock GitHub Comments API for Issue 101
+  await page.route('**/repos/chatelao/AI-Dashboard/issues/101/comments*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          user: { login: 'google-labs-jules[bot]' },
+          body: 'Jules is on it. View progress at https://jules.google.com/session/123'
+        }
+      ])
+    });
+  });
+
+  // Mock Jules API for Session 123
+  await page.route('**/v1alpha/session/123', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        sessions: [
-          {
-            name: 'sessions/123',
-            state: 'STATE_CODING',
-            url: 'https://jules.google.com/session/123'
-          }
-        ]
+        name: 'sessions/123',
+        state: 'STATE_CODING',
+        url: 'https://jules.google.com/session/123'
       })
     });
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,16 +107,56 @@ function App() {
     return results.flat();
   };
 
-  const fetchJulesStatus = async (issueId: number, token: string): Promise<{ status: string; url?: string } | undefined> => {
+  const extractSessionId = (text: string): string | undefined => {
+    // Try to find common patterns for session/task IDs in Jules comments
+    // 1. Markdown links like [Jules Task](.../sessions/ID) or .../session/ID or .../task/ID
+    const urlRegex = /jules\.google\.com\/(?:session|sessions|task)\/([a-zA-Z0-9_-]+)/;
+    const urlMatch = text.match(urlRegex);
+    if (urlMatch) return urlMatch[1];
+
+    // 2. Explicit task_id or session_id labels
+    const labelRegex = /(?:task_id|session_id|sessionId|taskId)[:=]\s*([a-zA-Z0-9_-]+)/i;
+    const labelMatch = text.match(labelRegex);
+    if (labelMatch) return labelMatch[1];
+
+    // 3. Look for a long numeric ID that looks like a session ID
+    const longIdRegex = /\b(\d{15,25})\b/;
+    const longIdMatch = text.match(longIdRegex);
+    if (longIdMatch) return longIdMatch[1];
+
+    return undefined;
+  };
+
+  const fetchSessionIdFromComments = async (repo: string, issueNumber: number, headers: HeadersInit): Promise<string | undefined> => {
+    try {
+      const response = await fetch(`https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=100`, { headers });
+      if (!response.ok) return undefined;
+      const comments: any[] = await response.json();
+
+      // Find the latest "on it" comment from Jules bot
+      const julesComments = comments.filter(c =>
+        (c.user?.login?.toLowerCase() === 'google-labs-jules[bot]' || c.user?.login?.toLowerCase() === 'jules') &&
+        c.body?.toLowerCase().includes('on it')
+      ).reverse();
+
+      for (const comment of julesComments) {
+        const sessionId = extractSessionId(comment.body);
+        if (sessionId) return sessionId;
+      }
+    } catch (err) {
+      console.error(`Error fetching comments for ${repo}#${issueNumber}:`, err);
+    }
+    return undefined;
+  };
+
+  const fetchJulesStatus = async (sessionId: string, token: string): Promise<{ status: string; url?: string } | undefined> => {
     let url;
-    // v1alpha uses /sessions with a filter or direct session access.
-    // We'll search for sessions related to the issue.
-    // For now, we assume Jules API is queried for a session associated with the issue.
+    // Use the exact session endpoint as requested
     if (julesApiBase.includes('?url=')) {
-      const targetUrl = `https://jules.googleapis.com/v1alpha/sessions?filter=prompt%20:%20%22%23${issueId}%22`;
+      const targetUrl = `https://jules.googleapis.com/v1alpha/session/${sessionId}`;
       url = `${julesApiBase}${encodeURIComponent(targetUrl)}`;
     } else {
-      url = `${julesApiBase}/sessions?filter=prompt%20:%20%22%23${issueId}%22`;
+      url = `${julesApiBase}/session/${sessionId}`;
     }
     console.log(`Fetching Jules status from: ${url}`);
     try {
@@ -133,29 +173,25 @@ function App() {
       }
 
       const response = await fetch(url, { headers });
-      console.log(`Jules API response status for issue ${issueId}: ${response.status}`);
+      console.log(`Jules API response status for session ${sessionId}: ${response.status}`);
       if (!response.ok) {
         if (response.status === 404) {
-          console.warn(`Jules API returned 404 for issue ${issueId}. Check your Jules API Base URL in Settings. It must end with /v1alpha (e.g., https://jules.googleapis.com/v1alpha) and your proxy must forward the Authorization header.`);
+          console.warn(`Jules API returned 404 for session ${sessionId}. Check your Jules API Base URL in Settings. It must end with /v1alpha (e.g., https://jules.googleapis.com/v1alpha) and your proxy must forward the Authorization header.`);
         }
         return undefined;
       }
       const data: any = await response.json();
-      console.log(`Jules API response data for issue ${issueId}:`, data);
+      console.log(`Jules API response data for session ${sessionId}:`, data);
 
-      // Look for the session in the list
-      if (data && data.sessions && Array.isArray(data.sessions) && data.sessions.length > 0) {
-        const session = data.sessions[0];
-        if (session.state) {
-          return {
-            status: session.state.replace('STATE_', '').replace(/_/g, '-').toLowerCase(),
-            url: session.url
-          };
-        }
+      if (data && data.state) {
+        return {
+          status: data.state.replace('STATE_', '').replace(/_/g, '-').toLowerCase(),
+          url: data.url
+        };
       }
       return undefined;
     } catch (err) {
-      console.error(`Failed to fetch Jules status for issue ${issueId}:`, err);
+      console.error(`Failed to fetch Jules status for session ${sessionId}:`, err);
       return undefined;
     }
   };
@@ -399,10 +435,13 @@ function App() {
               if (target.pull_request && target.enrichingPR === undefined) target.enrichingPR = true;
 
               if (target.isJules && julesToken) {
-                const result = await fetchJulesStatus(target.number, julesToken);
-                if (result) {
-                  target.julesStatus = result.status;
-                  target.julesUrl = result.url;
+                const sessionId = await fetchSessionIdFromComments(target.repository.full_name, target.number, headers);
+                if (sessionId) {
+                  const result = await fetchJulesStatus(sessionId, julesToken);
+                  if (result) {
+                    target.julesStatus = result.status;
+                    target.julesUrl = result.url;
+                  }
                 }
                 target.enrichingJules = false;
                 updated = true;

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -168,26 +168,54 @@ test.describe('Dashboard Consolidation', () => {
       });
     });
 
-    // Mock Jules API for Issue 201 (using 'url' field)
-    await page.route('**/v1/tasks/201/status', async (route) => {
+    // Mock GitHub Comments API for Issue 201
+    await page.route('**/repos/chatelao/AI-Dashboard/issues/201/comments*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            user: { login: 'google-labs-jules[bot]' },
+            body: 'Jules is on it. View progress at https://jules.google.com/session/201'
+          }
+        ])
+      });
+    });
+
+    // Mock GitHub Comments API for PR 202 (represented as issue comments in GitHub)
+    await page.route('**/repos/chatelao/AI-Dashboard/issues/202/comments*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            user: { login: 'google-labs-jules[bot]' },
+            body: 'Jules is on it. View progress at https://jules.google.com/session/202'
+          }
+        ])
+      });
+    });
+
+    // Mock Jules API for Session 201
+    await page.route('**/v1alpha/session/201', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          status: 'Coding',
+          state: 'STATE_CODING',
           url: 'https://jules.google.com/task/201'
         })
       });
     });
 
-    // Mock Jules API for PR 202 (using 'task_url' field)
-    await page.route('**/v1/tasks/202/status', async (route) => {
+    // Mock Jules API for Session 202
+    await page.route('**/v1alpha/session/202', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
-          status: 'Researching',
-          task_url: 'https://jules.google.com/task/202'
+          state: 'STATE_RESEARCHING',
+          url: 'https://jules.google.com/task/202'
         })
       });
     });
@@ -236,12 +264,26 @@ test.describe('Dashboard Consolidation', () => {
       });
     });
 
-    // Mock Jules API for Issue 301
-    await page.route('**/v1/tasks/301/status', async (route) => {
+    // Mock GitHub Comments API for Issue 301
+    await page.route('**/repos/chatelao/AI-Dashboard/issues/301/comments*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ status: 'Testing' })
+        body: JSON.stringify([
+          {
+            user: { login: 'jules' },
+            body: 'Jules is on it. task_id: 301'
+          }
+        ])
+      });
+    });
+
+    // Mock Jules API for Session 301
+    await page.route('**/v1alpha/session/301', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ state: 'STATE_TESTING' })
       });
     });
 
@@ -280,12 +322,26 @@ test.describe('Dashboard Consolidation', () => {
       });
     });
 
-    // Mock Jules API for Issue 401
-    await page.route('**/v1/tasks/401/status', async (route) => {
+    // Mock GitHub Comments API for Issue 401
+    await page.route('**/repos/chatelao/AI-Dashboard/issues/401/comments*', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ status: 'Completed' })
+        body: JSON.stringify([
+          {
+            user: { login: 'google-labs-jules[bot]' },
+            body: 'Jules is on it. 12345678901234567'
+          }
+        ])
+      });
+    });
+
+    // Mock Jules API for Session 12345678901234567
+    await page.route('**/v1alpha/session/12345678901234567', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ state: 'STATE_COMPLETED' })
       });
     });
 


### PR DESCRIPTION
This change updates the dashboard to use the exact Jules API method requested: `GET https://jules.googleapis.com/v1alpha/session/{$session_id}`.

The session ID is now dynamically extracted from GitHub issue comments. The application fetches comments for issues assigned to Jules, identifies the "Jules is on it" comment, and parses the session ID using regex patterns that handle Markdown links (e.g., `jules.google.com/session/ID`), explicit labels (`task_id: ID`), or long numeric IDs.

Key modifications:
- **web/src/App.tsx**: Added `extractSessionId` and `fetchSessionIdFromComments` helpers. Updated `fetchJulesStatus` and the background enrichment loop.
- **DATA_FETCHING.md**: Updated documentation to reflect the new session retrieval flow and API endpoint.
- **test/dashboard.spec.ts & web/tests/dashboard.spec.ts**: Updated Playwright tests to include mocks for the GitHub Comments API and the new Jules session endpoint.

Verification:
- All Playwright tests passed.
- Frontend UI was verified using a custom Playwright script that successfully demonstrated the extraction of a session ID from a mock comment and the display of the corresponding Jules status.

Fixes #169

---
*PR created automatically by Jules for task [13106770952124160050](https://jules.google.com/task/13106770952124160050) started by @chatelao*