### PR TITLE
Display PR file count and extensions on dashboard

### DIFF
--- a/test/pr_files.spec.ts
+++ b/test/pr_files.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+test('displays PR file count and extensions', async ({ page }) => {
+  // Set mock tokens
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+    (window as any).isTest = true;
+  });
+
+  // Mock GitHub Issues API
+  await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 101,
+          title: 'PR with files',
+          state: 'open',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/pull/101',
+          body: 'Some PR',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
+          assignee: null,
+          labels: [],
+          updated_at: new Date().toISOString(),
+          pull_request: {
+            url: 'https://api.github.com/repos/chatelao/AI-Dashboard/pulls/101',
+            html_url: 'https://github.com/chatelao/AI-Dashboard/pull/101'
+          }
+        }
+      ])
+    });
+  });
+
+  // Mock PR Detail API
+  await page.route('**/repos/chatelao/AI-Dashboard/pulls/101', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        mergeable: true,
+        mergeable_state: 'clean',
+        head: { sha: 'mock-sha' }
+      })
+    });
+  });
+
+  // Mock PR Files API
+  await page.route('**/repos/chatelao/AI-Dashboard/pulls/101/files', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { filename: 'file1.ts' },
+        { filename: 'file2.tsx' },
+        { filename: 'file3.ts' }
+      ])
+    });
+  });
+
+  // Mock Check Runs API
+  await page.route('**/repos/chatelao/AI-Dashboard/commits/mock-sha/check-runs', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total_count: 0, check_runs: [] })
+    });
+  });
+
+  await page.goto('/');
+
+  // Wait for the table and the enriched data
+  const prRow = page.locator('tr', { hasText: 'PR with files' });
+  await expect(prRow).toBeVisible();
+
+  // The text should contain "(3 files, .ts, .tsx)"
+  await expect(prRow).toContainText('(3 files, .ts, .tsx)');
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,8 @@ interface IssueWithJulesStatus extends GitHubIssue {
   mergeable?: boolean | null;
   mergeable_state?: string;
   actionLoading?: boolean;
+  prFilesCount?: number;
+  prFileExtensions?: string[];
 }
 
 const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1alpha';
@@ -400,6 +402,27 @@ function App() {
           // Sort by updated_at descending
           tempIssues.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
 
+          prsOnly.forEach(pr => {
+            if (!pr.body) {
+              tempIssues.push(pr as IssueWithJulesStatus);
+            } else {
+              const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+              let match;
+              let linked = false;
+              while ((match = regex.exec(pr.body)) !== null) {
+                const issueNumber = parseInt(match[1], 10);
+                const issueKey = `${pr.repository.full_name}#${issueNumber}`;
+                const issue = issuesByNumber.get(issueKey);
+                if (issue) {
+                  linked = true;
+                }
+              }
+              if (!linked) {
+                tempIssues.push(pr as IssueWithJulesStatus);
+              }
+            }
+          });
+
           allConsolidatedIssuesRef.current = tempIssues;
           lastFetchKeyRef.current = fetchKey;
           finalIssues = [...tempIssues];
@@ -497,6 +520,29 @@ function App() {
                     const prDetail: any = await prResponse.json();
                     target.mergeable = prDetail.mergeable;
                     target.mergeable_state = prDetail.mergeable_state;
+
+                    // Fetch PR files to get count and extensions
+                    try {
+                      const filesResponse = await fetch(
+                        `https://api.github.com/repos/${target.repository.full_name}/pulls/${target.number}/files`,
+                        { headers }
+                      );
+                      if (filesResponse.ok) {
+                        const filesData: any[] = await filesResponse.json();
+                        target.prFilesCount = filesData.length;
+                        const extensions = new Set<string>();
+                        filesData.forEach(file => {
+                          const parts = file.filename.split('.');
+                          if (parts.length > 1) {
+                            extensions.add(`.${parts.pop()}`);
+                          }
+                        });
+                        target.prFileExtensions = Array.from(extensions);
+                      }
+                    } catch (err) {
+                      console.error(`Failed to fetch files for PR #${target.number}`, err);
+                    }
+
                     const sha = prDetail?.head?.sha;
 
                     if (sha) {
@@ -680,11 +726,21 @@ function App() {
                       <div className="title-container">
                         <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
                           <span className="repo-tag">[{issue.repository.full_name.split('/')[1]}]</span> {issue.title}
+                          {issue.prFilesCount !== undefined && (
+                            <span className="pr-files-info">
+                              {' '}({issue.prFilesCount} {issue.prFilesCount === 1 ? 'file' : 'files'}{issue.prFileExtensions && issue.prFileExtensions.length > 0 ? `, ${issue.prFileExtensions.join(', ')}` : ''})
+                            </span>
+                          )}
                         </a>
                         {issue.linkedPRs && issue.linkedPRs.map(pr => (
                           <div key={pr.id} className="subtitle">
                             <a href={pr.html_url} target="_blank" rel="noopener noreferrer">
                               <span className="pr-number">PR #{pr.number}:</span> {pr.title}
+                              {pr.prFilesCount !== undefined && (
+                                <span className="pr-files-info">
+                                  {' '}({pr.prFilesCount} {pr.prFilesCount === 1 ? 'file' : 'files'}{pr.prFileExtensions && pr.prFileExtensions.length > 0 ? `, ${pr.prFileExtensions.join(', ')}` : ''})
+                                </span>
+                              )}
                             </a>
                           </div>
                         ))}


### PR DESCRIPTION
Added functionality to display the number of files changed and their extensions for pull requests on the dashboard. This information is fetched from the GitHub API and displayed in parentheses after the PR title (e.g., "(5 files, .ts, .tsx)"). 

Also fixed a regression where pull requests that were not linked to any issue were being filtered out of the consolidated view.

Verified with new Playwright tests and manual frontend verification with screenshots.

Fixes #175

---
*PR created automatically by Jules for task [2811907495525017598](https://jules.google.com/task/2811907495525017598) started by @chatelao*