### PR TITLE
Fix Jules API 404 by using plural /sessions/ endpoint

### DIFF
--- a/DATA_FETCHING.md
+++ b/DATA_FETCHING.md
@@ -21,8 +21,8 @@ For issues and pull requests identified as Jules tasks, the dashboard fetches th
 - **Identification:** An item is considered a Jules task if:
     - The assignee is `jules` or `google-labs-jules[bot]`.
     - It has a label named `Jules` (case-insensitive).
-- **Session ID Retrieval:** The application fetches GitHub issue comments and searches for the latest "Jules is on it" comment from the Jules bot. It extracts the session ID from Markdown links (e.g., `jules.google.com/session/ID`), explicit labels (`task_id: ID`), or long numeric patterns.
-- **Endpoint:** `https://jules.googleapis.com/v1alpha/session/${sessionId}`
+- **Session ID Retrieval:** The application fetches GitHub issue comments and searches for the latest "Jules is on it" comment from the Jules bot. It extracts the session ID from Markdown links (e.g., `jules.google.com/sessions/ID`), explicit labels (`task_id: ID`), or long numeric patterns.
+- **Endpoint:** `https://jules.googleapis.com/v1alpha/sessions/${sessionId}`
 - **Authentication:** Uses a Jules API Token stored in `localStorage` as `jules_token`. It is sent in the `Authorization` header using the `Bearer <TOKEN>` format.
 
 ## Data Processing

--- a/reproduction/proxy.php
+++ b/reproduction/proxy.php
@@ -82,7 +82,7 @@ if (strpos($targetUrl, '/v1alpha/sessions') !== false) {
             [
                 'name' => 'sessions/mock-' . $issueNumber,
                 'state' => 'STATE_CODING',
-                'url' => 'https://jules.google.com/session/mock-' . $issueNumber,
+                'url' => 'https://jules.google.com/sessions/mock-' . $issueNumber,
                 'prompt' => "Fix issue #$issueNumber",
                 'createTime' => date('c')
             ]

--- a/test/auth_aq_token.spec.ts
+++ b/test/auth_aq_token.spec.ts
@@ -52,7 +52,7 @@ test('uses X-Goog-Api-Key for AQ. tokens', async ({ page }) => {
 
   // Intercept and verify Jules API call
   let capturedHeaders: Record<string, string> = {};
-  await page.route('**/v1alpha/session/8999703094344754233', async (route) => {
+  await page.route('**/v1alpha/sessions/8999703094344754233', async (route) => {
     capturedHeaders = route.request().headers();
     await route.fulfill({
       status: 200,
@@ -124,7 +124,7 @@ test('uses Authorization for other tokens (e.g. ya29.)', async ({ page }) => {
 
   // Intercept and verify Jules API call
   let capturedHeaders: Record<string, string> = {};
-  await page.route('**/v1alpha/session/8999703094344754233', async (route) => {
+  await page.route('**/v1alpha/sessions/8999703094344754233', async (route) => {
     capturedHeaders = route.request().headers();
     await route.fulfill({
       status: 200,

--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -47,21 +47,21 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
       body: JSON.stringify([
         {
           user: { login: 'google-labs-jules[bot]' },
-          body: 'Jules is on it. View progress at https://jules.google.com/session/123'
+          body: 'Jules is on it. View progress at https://jules.google.com/sessions/123'
         }
       ])
     });
   });
 
   // Mock Jules API for Session 123
-  await page.route('**/v1alpha/session/123', async (route) => {
+  await page.route('**/v1alpha/sessions/123', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
         name: 'sessions/123',
         state: 'STATE_CODING',
-        url: 'https://jules.google.com/session/123'
+        url: 'https://jules.google.com/sessions/123'
       })
     });
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -122,8 +122,8 @@ function App() {
 
   const extractSessionId = (text: string): string | undefined => {
     // Try to find common patterns for session/task IDs in Jules comments
-    // 1. Markdown links like [Jules Task](.../sessions/ID) or .../session/ID or .../task/ID
-    const urlRegex = /jules\.google\.com\/(?:session|sessions|task)\/([a-zA-Z0-9_-]+)/;
+    // 1. Markdown links like [Jules Task](.../sessions/ID) or .../task/ID
+    const urlRegex = /jules\.google\.com\/(?:sessions|task)\/([a-zA-Z0-9_-]+)/;
     const urlMatch = text.match(urlRegex);
     if (urlMatch) return urlMatch[1];
 
@@ -166,10 +166,10 @@ function App() {
     let url;
     // Use the exact session endpoint as requested
     if (julesApiBase.includes('?url=')) {
-      const targetUrl = `https://jules.googleapis.com/v1alpha/session/${sessionId}`;
+      const targetUrl = `https://jules.googleapis.com/v1alpha/sessions/${sessionId}`;
       url = `${julesApiBase}${encodeURIComponent(targetUrl)}`;
     } else {
-      url = `${julesApiBase}/session/${sessionId}`;
+      url = `${julesApiBase}/sessions/${sessionId}`;
     }
     console.log(`Fetching Jules status from: ${url}`);
     try {
@@ -189,7 +189,7 @@ function App() {
       console.log(`Jules API response status for session ${sessionId}: ${response.status}`);
       if (!response.ok) {
         if (response.status === 404) {
-          console.warn(`Jules API returned 404 for session ${sessionId}. Check your Jules API Base URL in Settings. It must end with /v1alpha (e.g., https://jules.googleapis.com/v1alpha) and your proxy must forward the Authorization header.`);
+          console.warn(`Jules API returned 404 for session ${sessionId}. Check your Jules API Base URL in Settings. It must end with /v1alpha (e.g., https://jules.googleapis.com/v1alpha) and ensure you are using the plural /sessions/ endpoint.`);
         }
         return undefined;
       }

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -176,7 +176,7 @@ test.describe('Dashboard Consolidation', () => {
         body: JSON.stringify([
           {
             user: { login: 'google-labs-jules[bot]' },
-            body: 'Jules is on it. View progress at https://jules.google.com/session/201'
+            body: 'Jules is on it. View progress at https://jules.google.com/sessions/201'
           }
         ])
       });
@@ -190,14 +190,14 @@ test.describe('Dashboard Consolidation', () => {
         body: JSON.stringify([
           {
             user: { login: 'google-labs-jules[bot]' },
-            body: 'Jules is on it. View progress at https://jules.google.com/session/202'
+            body: 'Jules is on it. View progress at https://jules.google.com/sessions/202'
           }
         ])
       });
     });
 
     // Mock Jules API for Session 201
-    await page.route('**/v1alpha/session/201', async (route) => {
+    await page.route('**/v1alpha/sessions/201', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -209,7 +209,7 @@ test.describe('Dashboard Consolidation', () => {
     });
 
     // Mock Jules API for Session 202
-    await page.route('**/v1alpha/session/202', async (route) => {
+    await page.route('**/v1alpha/sessions/202', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -279,7 +279,7 @@ test.describe('Dashboard Consolidation', () => {
     });
 
     // Mock Jules API for Session 301
-    await page.route('**/v1alpha/session/301', async (route) => {
+    await page.route('**/v1alpha/sessions/301', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -337,7 +337,7 @@ test.describe('Dashboard Consolidation', () => {
     });
 
     // Mock Jules API for Session 12345678901234567
-    await page.route('**/v1alpha/session/12345678901234567', async (route) => {
+    await page.route('**/v1alpha/sessions/12345678901234567', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',


### PR DESCRIPTION
This PR fixes a bug where Jules API calls were failing with 404 errors because the application was using the singular `/session/` endpoint instead of the required plural `/sessions/` endpoint for the v1alpha API. 

The fix includes:
1. **Core Logic Update**: Modified `web/src/App.tsx` to construct the correct plural URL.
2. **Documentation Update**: Updated `DATA_FETCHING.md` to guide users toward the correct endpoint.
3. **Test Synchronization**: Updated all existing Playwright tests to use the plural endpoint, ensuring CI/CD passes.
4. **Reproduction Update**: Fixed the mock response in the reproduction proxy.
5. **Enhanced Diagnostics**: Updated the console warning for 404 errors to explicitly suggest checking for the plural endpoint.

Verified by running the entire test suite (24/24 passed) and performing manual verification with a Playwright script and screenshot.

Fixes #176

---
*PR created automatically by Jules for task [15924462816953196961](https://jules.google.com/task/15924462816953196961) started by @chatelao*