### PR TITLE
Fix strange characters in Jules API responses

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -126,6 +126,7 @@ $ch = curl_init($targetUrl);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
+curl_setopt($ch, CURLOPT_ENCODING, ''); // Handle compressed responses
 
 // Forward headers (excluding Host and browser-specific headers that might cause issues)
 $curlHeaders = [];


### PR DESCRIPTION
The user reported seeing strange characters in Jules API responses. This was caused by the PHP proxy script not handling compressed (GZIP) responses from the Jules API. Adding `CURLOPT_ENCODING` set to an empty string tells libcurl to handle all supported compression formats and decompress the response before returning it. I have updated the documentation in `CORS_PROXY.md` to include this fix.

Fixes #179

---
*PR created automatically by Jules for task [2556388883012054917](https://jules.google.com/task/2556388883012054917) started by @chatelao*