### PR TITLE
Rename title to Dashboard

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -4,7 +4,7 @@ test('has title', async ({ page }) => {
   await page.goto('/');
 
   // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/AI-Dashboard/);
+  await expect(page).toHaveTitle(/Dashboard/);
 
   // Expect the description text to NOT be present.
   await expect(page.locator('text=Unified view of GitHub Issues and Google Jules Statuses')).not.toBeVisible();

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI-Dashboard</title>
+    <title>Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -633,7 +633,7 @@ function App() {
       <header>
         <div className="header-content">
           <div>
-            <h1>AI-Dashboard</h1>
+            <h1>Dashboard</h1>
           </div>
           <div className="header-filter">
             <input


### PR DESCRIPTION
Renamed the application's display title from "AI-Dashboard" to "Dashboard". This change affects the browser tab title and the main heading visible on the page. The corresponding test assertion was also updated to ensure consistency.

Fixes #186

---
*PR created automatically by Jules for task [2426989895305589260](https://jules.google.com/task/2426989895305589260) started by @chatelao*