### PR TITLE
Refresh dashboard on visibility change

### DIFF
--- a/test/visibility.spec.ts
+++ b/test/visibility.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+test('dashboard refreshes when becoming visible', async ({ page }) => {
+  // Mock GitHub API responses
+  await page.route('https://api.github.com/repos/chatelao/AI-Dashboard/issues*', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 1,
+          title: 'Test Issue',
+          state: 'open',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/1',
+          body: 'Test body',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
+          updated_at: new Date().toISOString(),
+          labels: []
+        }
+      ])
+    });
+  });
+
+  await page.goto('http://localhost:5173/AI-Dashboard/?test=true');
+
+  // Wait for initial load
+  await expect(page.locator('text=Test Issue')).toBeVisible();
+
+  // Track the number of requests to the issues API
+  let requestCount = 0;
+  await page.route('https://api.github.com/repos/chatelao/AI-Dashboard/issues*', async route => {
+    requestCount++;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 1,
+          title: 'Test Issue Updated',
+          state: 'open',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/1',
+          body: 'Test body',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
+          updated_at: new Date().toISOString(),
+          labels: []
+        }
+      ])
+    });
+  });
+
+  // Simulate visibility change to hidden then visible
+  await page.evaluate(() => {
+    // We need to mock the property because it's read-only
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', writable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  // Should not have refreshed yet
+  expect(requestCount).toBe(0);
+
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', writable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  // Wait for the refresh to happen
+  await expect(page.locator('text=Test Issue Updated')).toBeVisible();
+  expect(requestCount).toBeGreaterThan(0);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,6 +90,20 @@ function App() {
       setDraftRepoHistory(repoHistory.join(', '));
     }
   }, [showSettings, ghToken, julesToken, julesApiBase, repoHistory]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        setRefreshTrigger(prev => prev + 1);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
   const [filterState] = useState<'all' | 'open'>(
     (localStorage.getItem('filter_state') as 'all' | 'open') || 'all'
   );


### PR DESCRIPTION
The dashboard now automatically refreshes its data whenever it becomes visible again (e.g., when the user switches back to its tab). This was implemented using a React `useEffect` hook that listens for the `visibilitychange` event on the document. When the state transitions to `'visible'`, it increments the existing `refreshTrigger` state, initiating a data update. A new Playwright test was added to verify this behavior by mocking API responses and simulating visibility changes.

Fixes #188

---
*PR created automatically by Jules for task [2514074202201816957](https://jules.google.com/task/2514074202201816957) started by @chatelao*