### PR TITLE
Fix in-progress label to InProgress and improve status capitalization

### DIFF
--- a/test/dashboard.spec.ts
+++ b/test/dashboard.spec.ts
@@ -79,7 +79,7 @@ test('dashboard loads issues and displays Jules status', async ({ page }) => {
   // but since we want to be specific about the columns:
   const row101 = page.locator('tr', { has: page.locator('text=Jules issue') });
   await expect(row101.locator('td').nth(0)).toContainText('[AI-Dashboard]');
-  await expect(row101.locator('td').nth(3)).toContainText('coding');
+  await expect(row101.locator('td').nth(3)).toContainText('Coding');
 });
 
 test('dashboard displays InProgress for STATE_IN_PROGRESS', async ({ page }) => {

--- a/test/inprogress.spec.ts
+++ b/test/inprogress.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test('should display InProgress for in-progress status', async ({ page }) => {
+  // Set mock jules_token
+  await page.addInitScript(() => {
+    window.localStorage.setItem('jules_token', 'mock-jules-token');
+  });
+
+  // Mock GitHub Issues API
+  await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 1,
+          title: 'In Progress Issue',
+          state: 'open',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/1',
+          body: 'Working on it',
+          assignee: { login: 'Jules' },
+          labels: [],
+          repository: { full_name: 'chatelao/AI-Dashboard' }
+        }
+      ])
+    });
+  });
+
+  // Mock GitHub Comments API
+  await page.route('**/repos/chatelao/AI-Dashboard/issues/1/comments*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          user: { login: 'google-labs-jules[bot]' },
+          body: 'Jules is on it. task_id: 1'
+        }
+      ])
+    });
+  });
+
+  // Mock Jules API for Session 1
+  await page.route('**/v1alpha/sessions/1', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        state: 'IN_PROGRESS'
+      })
+    });
+  });
+
+  await page.goto('/?test=true');
+
+  const julesStatusBadge = page.locator('.badge.jules-status-in-progress');
+  await expect(julesStatusBadge).toBeVisible();
+  await expect(julesStatusBadge).toHaveText('InProgress');
+});

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -255,7 +255,6 @@ a:hover {
   border-radius: 4px;
   font-size: 0.8rem;
   font-weight: bold;
-  text-transform: capitalize;
 }
 
 .state-open {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -113,7 +113,11 @@ function App() {
   const [refreshTrigger, setRefreshTrigger] = useState<number>(0);
 
   const formatJulesStatus = (status: string) => {
-    return status === 'in-progress' ? 'InProgress' : status.replace(/-/g, ' ');
+    if (status === 'in-progress') return 'InProgress';
+    return status
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
   };
 
   const fetchRawIssues = async (repo: string, filterState: string, headers: HeadersInit): Promise<GitHubIssue[]> => {
@@ -781,7 +785,7 @@ function App() {
                     </td>
                     <td data-label="State">
                       <span className={`badge state-${issue.state}`}>
-                        {issue.state}
+                        {issue.state.charAt(0).toUpperCase() + issue.state.slice(1)}
                       </span>
                     </td>
                     <td data-label="PR">


### PR DESCRIPTION
The "in-progress" status label was rendered as "In progress" due to CSS capitalization, which didn't look as desired. I've updated the application logic to explicitly render it as "InProgress" and moved all status capitalization logic from CSS to TypeScript for better control and consistency. This also includes capitalizing GitHub issue states (Open/Closed) in the UI.

Fixes #185

---
*PR created automatically by Jules for task [5819993511164800667](https://jules.google.com/task/5819993511164800667) started by @chatelao*