### PR TITLE
Enable private repository visibility and update GitHub authentication to Bearer

### DIFF
--- a/DATA_FETCHING.md
+++ b/DATA_FETCHING.md
@@ -13,7 +13,7 @@ The dashboard uses the GitHub REST API to fetch issues and pull requests for the
     - Each request fetches 100 items per page (`per_page=100`).
     - The `state` parameter is controlled by the dashboard filter (e.g., `open` or `all`).
     - Fetching stops early if a page returns fewer than 100 items or an empty list.
-- **Authentication:** Uses a Personal Access Token (PAT) stored in `localStorage` as `github_token`. It is sent in the `Authorization` header using the `token <TOKEN>` format.
+- **Authentication:** Uses a Personal Access Token (PAT) stored in `localStorage` as `github_token`. It is sent in the `Authorization` header using the `Bearer <TOKEN>` format.
 
 ### 2. Jules API
 For issues and pull requests identified as Jules tasks, the dashboard fetches their status from the Jules API.

--- a/HOWTO_ENABLE_PRIVATE.md
+++ b/HOWTO_ENABLE_PRIVATE.md
@@ -1,0 +1,46 @@
+# How to Enable Private Repositories
+
+To see issues and pull requests from private repositories in the Dashboard, you need to provide a GitHub Personal Access Token (PAT) with the appropriate permissions.
+
+## 1. Create a GitHub Personal Access Token
+
+You can use either a **Fine-grained token** (recommended) or a **Classic token**.
+
+### Option A: Fine-grained personal access token (Recommended)
+1. Go to [GitHub Settings > Developer settings > Personal access tokens > Fine-grained tokens](https://github.com/settings/tokens?type=beta).
+2. Click **Generate new token**.
+3. Give it a name and expiration date.
+4. **Repository access:** Select "All repositories" or "Only select repositories" (and pick the private ones you want).
+5. **Permissions:**
+   - **Repository permissions:**
+     - `Issues`: Read-only (or Read & write if you want to use Jules features)
+     - `Pull requests`: Read-only (or Read & write if you want to use Merge/Update features)
+     - `Metadata`: Read-only (mandatory)
+     - `Commit statuses`: Read-only (for CI/CD status)
+6. Click **Generate token** and copy it.
+
+### Option B: Tokens (classic)
+1. Go to [GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)](https://github.com/settings/tokens).
+2. Click **Generate new token > Generate new token (classic)**.
+3. Select the `repo` scope (this grants full control of private repositories).
+4. Click **Generate token** and copy it.
+
+## 2. Configure the Dashboard
+
+1. Open the Dashboard.
+2. Click the **Settings (⚙️)** icon in the top right.
+3. Paste your token into the **GitHub Personal Access Token** field.
+4. In the **Tracked Repositories** field, ensure your private repositories are listed (e.g., `your-org/private-repo, your-user/another-private-repo`).
+   - If you leave this field empty, the dashboard will try to automatically fetch all repositories you have access to.
+5. Click **Save & Reload**.
+
+## 3. Troubleshooting
+
+### SAML / SSO
+If your private repository belongs to an organization that uses SAML Single Sign-On (SSO), you must authorize your PAT:
+1. In your GitHub [Personal Access Tokens list](https://github.com/settings/tokens), find the token you created.
+2. Click **Configure SSO** next to the token.
+3. Click **Authorize** for the relevant organization.
+
+### Token Format
+The Dashboard uses the `Bearer` authentication scheme. If you are using a proxy, ensure it forwards the `Authorization` header correctly.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -275,7 +275,7 @@ function App() {
       const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${pullNumber}/update-branch`, {
         method: 'PUT',
         headers: {
-          'Authorization': `token ${ghToken}`,
+          'Authorization': `Bearer ${ghToken}`,
           'Accept': 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28'
         }
@@ -300,7 +300,7 @@ function App() {
       const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${pullNumber}/merge`, {
         method: 'PUT',
         headers: {
-          'Authorization': `token ${ghToken}`,
+          'Authorization': `Bearer ${ghToken}`,
           'Accept': 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28'
         }
@@ -343,7 +343,7 @@ function App() {
       try {
         const headers: HeadersInit = {};
         if (ghToken) {
-          headers['Authorization'] = `token ${ghToken}`;
+          headers['Authorization'] = `Bearer ${ghToken}`;
         }
 
         const fetchKey = JSON.stringify([ghToken, repoHistory, filterState, refreshTrigger]);


### PR DESCRIPTION
This PR addresses the issue where issues from private repositories were not visible. It provides a comprehensive guide (`HOWTO_ENABLE_PRIVATE.md`) on how to configure the dashboard with a GitHub Personal Access Token (PAT) and ensures the application uses the modern `Bearer` authentication scheme, which is required for GitHub's fine-grained PATs.

Key changes:
- Added `HOWTO_ENABLE_PRIVATE.md`.
- Refactored `web/src/App.tsx` to use `Bearer` authentication for all GitHub API calls.
- Updated `DATA_FETCHING.md` to keep documentation in sync with implementation.
- Verified functionality with existing Playwright tests and manual UI inspection.

Fixes #193

---
*PR created automatically by Jules for task [6361269775749467488](https://jules.google.com/task/6361269775749467488) started by @chatelao*