### PR TITLE
Add swisscarport-admin to defaults and improve repo sanitization

### DIFF
--- a/test/sanitization.spec.ts
+++ b/test/sanitization.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+test('sanitizes repository names in settings', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+    (window as any).isTest = true;
+  });
+
+  // Mock repo1 issues
+  await page.route('**/repos/repo1/a/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 1,
+          title: 'Issue from repo1',
+          state: 'open',
+          html_url: 'https://github.com/repo1/a/issues/1',
+          updated_at: '2023-10-01T12:00:00Z',
+          repository: { full_name: 'repo1/a' },
+          assignee: null,
+          labels: []
+        }
+      ])
+    });
+  });
+
+  await page.route('**/repos/repo1/a/pulls?state=all*', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.goto('/');
+
+  // Open settings
+  await page.click('button[aria-label="Settings"]');
+
+  // Input dirty repo URL
+  const repoInput = page.locator('#repo-history');
+  await repoInput.fill(' https://github.com/repo1/a ');
+
+  // Save settings
+  const savePromise = page.waitForResponse('**/repos/repo1/a/issues?state=all*');
+  await page.click('button.btn-save');
+  await savePromise;
+
+  // Verify it was sanitized and fetches data
+  await expect(page.locator('text=[a] Issue from repo1')).toBeVisible();
+
+  // Re-open settings to check value
+  await page.click('button[aria-label="Settings"]');
+  await expect(repoInput).toHaveValue('repo1/a');
+});
+
+test('migrates from old default repo to new default list', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+    window.localStorage.setItem('gh_repos', JSON.stringify(['chatelao/AI-Dashboard']));
+    (window as any).isTest = true;
+  });
+
+  // Mock AI-Dashboard
+  await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 1, number: 1, title: 'AI-Dashboard Issue', state: 'open', html_url: '...', updated_at: '...', repository: { full_name: 'chatelao/AI-Dashboard' }, assignee: null, labels: [] }])
+    });
+  });
+  await page.route('**/repos/chatelao/AI-Dashboard/pulls?state=all*', async (route) => { await route.fulfill({ body: '[]' }); });
+
+  // Mock swisscarport-admin
+  await page.route('**/repos/chatelao/swisscarport-admin/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 2, number: 2, title: 'Swisscarport Issue', state: 'open', html_url: '...', updated_at: '...', repository: { full_name: 'chatelao/swisscarport-admin' }, assignee: null, labels: [] }])
+    });
+  });
+  await page.route('**/repos/chatelao/swisscarport-admin/pulls?state=all*', async (route) => { await route.fulfill({ body: '[]' }); });
+
+  await page.goto('/');
+
+  // Verify both issues are present (meaning both repos were loaded)
+  await expect(page.locator('text=[AI-Dashboard] AI-Dashboard Issue')).toBeVisible();
+  await expect(page.locator('text=[swisscarport-admin] Swisscarport Issue')).toBeVisible();
+
+  // Check settings value
+  await page.click('button[aria-label="Settings"]');
+  const repoInput = page.locator('#repo-history');
+  await expect(repoInput).toHaveValue('chatelao/AI-Dashboard, chatelao/swisscarport-admin');
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,6 +45,21 @@ interface IssueWithJulesStatus extends GitHubIssue {
 }
 
 const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1alpha';
+const DEFAULT_REPOS = ['chatelao/AI-Dashboard', 'chatelao/swisscarport-admin'];
+
+const sanitizeRepoName = (input: string): string => {
+  let cleaned = input.trim();
+  // Remove https://github.com/ if present
+  cleaned = cleaned.replace(/^https?:\/\/github\.com\//i, '');
+  // Remove leading slash if present
+  cleaned = cleaned.replace(/^\//, '');
+  // Take only owner/repo
+  const parts = cleaned.split('/');
+  if (parts.length >= 2) {
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return cleaned;
+};
 
 function App() {
   const [issues, setIssues] = useState<IssueWithJulesStatus[]>([]);
@@ -60,7 +75,19 @@ function App() {
 
   const [repoHistory, setRepoHistory] = useState<string[]>(() => {
     const saved = localStorage.getItem('gh_repos');
-    return saved ? JSON.parse(saved) : ['chatelao/AI-Dashboard'];
+    if (saved) {
+      try {
+        const repos: string[] = JSON.parse(saved).map(sanitizeRepoName).filter((r: string) => r.length > 0);
+        // Migration: if they only have the old default, upgrade them to the new default list
+        if (repos.length === 1 && repos[0] === 'chatelao/AI-Dashboard') {
+          return DEFAULT_REPOS;
+        }
+        return repos;
+      } catch (e) {
+        console.error('Failed to parse gh_repos from localStorage', e);
+      }
+    }
+    return DEFAULT_REPOS;
   });
   const [draftRepoHistory, setDraftRepoHistory] = useState<string>(repoHistory.join(', '));
 
@@ -239,7 +266,10 @@ function App() {
   };
 
   const handleSaveSettings = () => {
-    const newRepos = draftRepoHistory.split(',').map(r => r.trim()).filter(r => r.length > 0);
+    const newRepos = draftRepoHistory
+      .split(',')
+      .map(sanitizeRepoName)
+      .filter(r => r.length > 0);
     localStorage.setItem('github_token', draftGhToken);
     localStorage.setItem('jules_token', draftJulesToken);
     localStorage.setItem('jules_api_base', draftJulesApiBase);


### PR DESCRIPTION
Added 'chatelao/swisscarport-admin' to the default repository list and implemented a migration for existing users who only had the old default. Also implemented the 'sanitizeRepoName' utility function to extract 'owner/repo' from GitHub URLs and trim whitespace, and integrated it into the settings saving and initialization logic. Verified with new Playwright tests and frontend verification.

Fixes #195

---
*PR created automatically by Jules for task [786206421138712354](https://jules.google.com/task/786206421138712354) started by @chatelao*