### PR TITLE
Add SAML SSO authorization button to repo error banner

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -538,6 +538,22 @@ a:hover {
   background-color: #2ea043;
 }
 
+.btn-sso {
+  background-color: #238636;
+  color: #ffffff;
+  border-color: rgba(240, 246, 252, 0.1);
+  text-decoration: none !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0;
+}
+
+.btn-sso:hover {
+  background-color: #2ea043;
+  color: #ffffff;
+}
+
 .repo-error-banner {
   background-color: rgba(248, 81, 73, 0.1);
   border: 1px solid rgba(248, 81, 73, 0.4);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,11 @@ interface IssueWithJulesStatus extends GitHubIssue {
   prFileExtensions?: string[];
 }
 
+interface RepoErrorInfo {
+  message: string;
+  ssoUrl?: string;
+}
+
 const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1alpha';
 const DEFAULT_REPOS = ['chatelao/AI-Dashboard', 'chatelao/swisscarport-admin'];
 
@@ -67,7 +72,7 @@ function App() {
   const [issues, setIssues] = useState<IssueWithJulesStatus[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [repoErrors, setRepoErrors] = useState<Record<string, string>>({});
+  const [repoErrors, setRepoErrors] = useState<Record<string, RepoErrorInfo>>({});
   const [ghToken, setGhToken] = useState<string>(localStorage.getItem('github_token') || '');
   const [julesToken, setJulesToken] = useState<string>(localStorage.getItem('jules_token') || '');
   const [julesApiBase, setJulesApiBase] = useState<string>(localStorage.getItem('jules_api_base') || DEFAULT_JULES_API_BASE);
@@ -179,7 +184,7 @@ function App() {
     repo: string,
     filterState: string,
     headers: HeadersInit,
-    onRepoError?: (repo: string, message: string) => void
+    onRepoError?: (repo: string, error: RepoErrorInfo) => void
   ): Promise<GitHubIssue[]> => {
     // Check if we are in a test environment (e.g., Playwright)
     const isTest = window.location.search.includes('test=true') || (window as any).isTest;
@@ -199,13 +204,35 @@ function App() {
         if (!response.ok) {
           if (page === 1) {
             let message = `Failed to fetch: ${response.status} ${response.statusText}`;
-            if (response.status === 404) {
-              message = 'Repository not found. If it is private, ensure your PAT has "repo" or "Issues" read scope.';
-            } else if (response.status === 403) {
-              message = 'Access forbidden. If this is an organization repo, you may need to authorize SAML SSO for your PAT.';
+            let ssoUrl: string | undefined;
+
+            const ssoHeader = response.headers.get('X-GitHub-SSO');
+            if (ssoHeader) {
+              const urlMatch = ssoHeader.match(/url=([^;]+)/);
+              if (urlMatch) {
+                ssoUrl = urlMatch[1];
+              }
             }
+
+            try {
+              const errorData: any = await response.json();
+              if (errorData.message) {
+                message = errorData.message;
+              }
+            } catch (e) {
+              // Not JSON or no message
+            }
+
+            if (response.status === 404 && message.includes('Not Found')) {
+              message = 'Repository not found. If it is private, ensure your PAT has "repo" or "Issues" read scope.';
+            } else if (response.status === 403 && !ssoUrl && message.includes('API rate limit exceeded')) {
+              // Keep rate limit message as is
+            } else if (response.status === 403 && !ssoUrl) {
+              message = `Access forbidden: ${message}`;
+            }
+
             console.error(`Error for ${repo}: ${message}`);
-            onRepoError?.(repo, message);
+            onRepoError?.(repo, { message, ssoUrl });
           }
           return [];
         }
@@ -446,8 +473,8 @@ function App() {
           }
 
           const allReposResults = await Promise.all(
-            effectiveRepoList.map(repo => fetchRawIssues(repo, filterState, headers, (r, msg) => {
-              setRepoErrors(prev => ({ ...prev, [r]: msg }));
+            effectiveRepoList.map(repo => fetchRawIssues(repo, filterState, headers, (r, errorInfo) => {
+              setRepoErrors(prev => ({ ...prev, [r]: errorInfo }));
             }))
           );
 
@@ -839,9 +866,23 @@ function App() {
             <p>Issues from these repositories are missing from the dashboard.</p>
           </div>
           <ul>
-            {Object.entries(repoErrors).map(([repo, msg]) => (
+            {Object.entries(repoErrors).map(([repo, errorInfo]) => (
               <li key={repo}>
-                <strong>{repo}:</strong> {msg}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '8px' }}>
+                  <span>
+                    <strong>{repo}:</strong> {errorInfo.message}
+                  </span>
+                  {errorInfo.ssoUrl && (
+                    <a
+                      href={errorInfo.ssoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn-action btn-sso"
+                    >
+                      Authorize
+                    </a>
+                  )}
+                </div>
               </li>
             ))}
           </ul>

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -357,4 +357,72 @@ test.describe('Dashboard Consolidation', () => {
     // Verify Issue 401 status
     await expect(issueRow.locator('td').nth(3)).toContainText('completed', { ignoreCase: true });
   });
+
+  test('should display Authorize button when SAML SSO is required', async ({ page }) => {
+    const repo = 'org/private-repo';
+
+    // Mock GitHub Issues API with 403 and X-GitHub-SSO header
+    await page.route(`**/repos/${repo}/issues*`, async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        headers: {
+          'X-GitHub-SSO': 'required; url=https://github.com/orgs/org/sso?authorization_request=XYZ',
+          'Access-Control-Expose-Headers': 'X-GitHub-SSO'
+        },
+        body: JSON.stringify({
+          message: 'Resource protected by organization SAML enforcement. You must grant your personal access token access to this organization.',
+          documentation_url: 'https://docs.github.com/articles/authenticating-with-saml-single-sign-on/'
+        })
+      });
+    });
+
+    // Set repo in localStorage
+    await page.addInitScript((repo) => {
+      window.localStorage.setItem('gh_repos', JSON.stringify([repo]));
+    }, repo);
+
+    await page.goto('/?test=true');
+
+    // Verify error banner exists
+    const errorBanner = page.locator('.repo-error-banner');
+    await expect(errorBanner).toBeVisible();
+
+    // Verify repo-specific error message
+    const repoError = errorBanner.locator('li').filter({ hasText: repo });
+    await expect(repoError).toContainText('Resource protected by organization SAML enforcement');
+
+    // Verify Authorize button exists and has correct URL
+    const authButton = repoError.locator('a.btn-sso');
+    await expect(authButton).toBeVisible();
+    await expect(authButton).toHaveAttribute('href', 'https://github.com/orgs/org/sso?authorization_request=XYZ');
+    await expect(authButton).toHaveText('Authorize');
+  });
+
+  test('should display detailed error message for rate limit errors', async ({ page }) => {
+    const repo = 'chatelao/AI-Dashboard';
+
+    // Mock GitHub Issues API with 403 Rate Limit
+    await page.route(`**/repos/${repo}/issues*`, async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: "API rate limit exceeded for user ID 12345. If you reach out to GitHub Support, please include this entire message and the following: 123:456:789",
+          documentation_url: "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"
+        })
+      });
+    });
+
+    await page.goto('/?test=true');
+
+    // Verify error banner exists
+    const errorBanner = page.locator('.repo-error-banner');
+    await expect(errorBanner).toBeVisible();
+
+    // Verify detailed rate limit message is shown
+    const repoError = errorBanner.locator('li').filter({ hasText: repo });
+    await expect(repoError).toContainText('API rate limit exceeded');
+    await expect(repoError).toContainText('user ID 12345');
+  });
 });


### PR DESCRIPTION
This change improves the dashboard's handling of repository access errors, specifically targeting SAML SSO enforcement which was causing several repositories to fail silently or with generic messages.

Key improvements:
1. **SSO Detection**: The application now parses the `X-GitHub-SSO` header from 403 responses.
2. **Actionable Feedback**: When SSO is required, an "Authorize" button appears next to the repository name, leading the user directly to the organization's authorization page.
3. **Better Error Messages**: Instead of hardcoded suggestions, the dashboard now displays the actual `message` returned by the GitHub API, providing better context for rate limits or other permission issues.
4. **Enhanced UI**: Added styling for the new SSO button and updated the error banner to handle multi-line repo errors gracefully.
5. **Testing**: Added new Playwright tests in `web/tests/dashboard.spec.ts` to mock these scenarios and ensure they are handled correctly.

Fixes #199

---
*PR created automatically by Jules for task [17694339703737720373](https://jules.google.com/task/17694339703737720373) started by @chatelao*