### PR TITLE
Add Authorize button for SAML SSO 403 errors

### DIFF
--- a/test/sso_auth.spec.ts
+++ b/test/sso_auth.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test('displays Authorize button on 403 with X-GitHub-SSO header', async ({ page }) => {
+  // Set mock tokens and repo history
+  await page.addInitScript(() => {
+    window.localStorage.setItem('github_token', 'mock-gh-token');
+    window.localStorage.setItem('gh_repos', JSON.stringify(['org/private-repo']));
+    (window as any).isTest = true;
+  });
+
+  // Mock GitHub Issues API to return 403 with SSO header
+  const ssoUrl = 'https://github.com/orgs/org/sso?authorization_request=...';
+  await page.route('**/repos/org/private-repo/issues?state=all*', async (route) => {
+    await route.fulfill({
+      status: 403,
+      headers: {
+        'X-GitHub-SSO': `required; url=${ssoUrl}`,
+        'Access-Control-Expose-Headers': 'X-GitHub-SSO'
+      },
+      contentType: 'application/json',
+      body: JSON.stringify({
+        message: 'Resource protected by SAML single sign-on',
+        documentation_url: 'https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on'
+      })
+    });
+  });
+
+  await page.goto('/');
+
+  // Verify the error banner is visible
+  const errorBanner = page.locator('.repo-error-banner');
+  await expect(errorBanner).toBeVisible();
+
+  // Verify the error message for the repo
+  await expect(errorBanner).toContainText('org/private-repo: Access forbidden');
+
+  // Verify the Authorize button is present and has the correct URL
+  const authButton = errorBanner.locator('a.btn-authorize');
+  await expect(authButton).toBeVisible();
+  await expect(authButton).toHaveAttribute('href', ssoUrl);
+  await expect(authButton).toHaveAttribute('target', '_blank');
+});

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -574,6 +574,31 @@ a:hover {
   margin-bottom: 0.3rem;
 }
 
+.repo-error-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.repo-error-text {
+  flex: 1;
+}
+
+.btn-authorize {
+  background-color: #238636;
+  color: #ffffff !important;
+  border-color: rgba(240, 246, 252, 0.1);
+  text-decoration: none !important;
+  margin-left: 0;
+  display: inline-block;
+}
+
+.btn-authorize:hover {
+  background-color: #2ea043;
+}
+
 .repo-error-banner li strong {
   color: #f85149;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,11 @@ interface PRStatus {
   label: string;
 }
 
+interface RepoErrorInfo {
+  message: string;
+  ssoUrl?: string;
+}
+
 interface IssueWithJulesStatus extends GitHubIssue {
   julesStatus?: string;
   julesUrl?: string;
@@ -67,7 +72,7 @@ function App() {
   const [issues, setIssues] = useState<IssueWithJulesStatus[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [repoErrors, setRepoErrors] = useState<Record<string, string>>({});
+  const [repoErrors, setRepoErrors] = useState<Record<string, RepoErrorInfo>>({});
   const [ghToken, setGhToken] = useState<string>(localStorage.getItem('github_token') || '');
   const [julesToken, setJulesToken] = useState<string>(localStorage.getItem('jules_token') || '');
   const [julesApiBase, setJulesApiBase] = useState<string>(localStorage.getItem('jules_api_base') || DEFAULT_JULES_API_BASE);
@@ -179,7 +184,7 @@ function App() {
     repo: string,
     filterState: string,
     headers: HeadersInit,
-    onRepoError?: (repo: string, message: string) => void
+    onRepoError?: (repo: string, error: RepoErrorInfo) => void
   ): Promise<GitHubIssue[]> => {
     // Check if we are in a test environment (e.g., Playwright)
     const isTest = window.location.search.includes('test=true') || (window as any).isTest;
@@ -199,13 +204,21 @@ function App() {
         if (!response.ok) {
           if (page === 1) {
             let message = `Failed to fetch: ${response.status} ${response.statusText}`;
+            let ssoUrl = undefined;
             if (response.status === 404) {
               message = 'Repository not found. If it is private, ensure your PAT has "repo" or "Issues" read scope.';
             } else if (response.status === 403) {
               message = 'Access forbidden. If this is an organization repo, you may need to authorize SAML SSO for your PAT.';
+              const ssoHeader = response.headers.get('X-GitHub-SSO');
+              if (ssoHeader) {
+                const match = ssoHeader.match(/url=([^;]+)/);
+                if (match) {
+                  ssoUrl = match[1];
+                }
+              }
             }
             console.error(`Error for ${repo}: ${message}`);
-            onRepoError?.(repo, message);
+            onRepoError?.(repo, { message, ssoUrl });
           }
           return [];
         }
@@ -446,8 +459,8 @@ function App() {
           }
 
           const allReposResults = await Promise.all(
-            effectiveRepoList.map(repo => fetchRawIssues(repo, filterState, headers, (r, msg) => {
-              setRepoErrors(prev => ({ ...prev, [r]: msg }));
+            effectiveRepoList.map(repo => fetchRawIssues(repo, filterState, headers, (r, err) => {
+              setRepoErrors(prev => ({ ...prev, [r]: err }));
             }))
           );
 
@@ -839,9 +852,21 @@ function App() {
             <p>Issues from these repositories are missing from the dashboard.</p>
           </div>
           <ul>
-            {Object.entries(repoErrors).map(([repo, msg]) => (
-              <li key={repo}>
-                <strong>{repo}:</strong> {msg}
+            {Object.entries(repoErrors).map(([repo, err]) => (
+              <li key={repo} className="repo-error-item">
+                <div className="repo-error-text">
+                  <strong>{repo}:</strong> {err.message}
+                </div>
+                {err.ssoUrl && (
+                  <a
+                    href={err.ssoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn-action btn-authorize"
+                  >
+                    Authorize
+                  </a>
+                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
The 403 error you encountered is common when accessing organization repositories that require SAML Single Sign-On (SSO). Even with a valid token, you must explicitly authorize it for each organization.

I've updated the dashboard to detect this specific scenario. Now, when a repository fails to load due to missing SSO authorization, a green **"Authorize"** button will appear directly in the error banner. Clicking it will take you to GitHub's authorization page for that organization.

**Changes:**
- **API Integration:** `fetchRawIssues` now checks for the `X-GitHub-SSO` header in 403 responses and extracts the required authorization URL.
- **UI Improvements:** Added a new `RepoErrorInfo` structure to track these URLs and a corresponding "Authorize" button in the repository error banner.
- **Testing:** Added a new Playwright test (`test/sso_auth.spec.ts`) that mocks the SSO 403 response to ensure the button appears correctly.
- **Styling:** Added CSS for the new button and improved the layout of repository error items.

Fixes #201

---
*PR created automatically by Jules for task [911119307854727806](https://jules.google.com/task/911119307854727806) started by @chatelao*