### PR TITLE
Add SAML SSO authorization options and improved error handling

### DIFF
--- a/CORS_PROXY.md
+++ b/CORS_PROXY.md
@@ -65,6 +65,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Access-Control-Allow-Origin: $origin");
     header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
     header("Access-Control-Allow-Headers: *");
+    header("Access-Control-Expose-Headers: X-GitHub-SSO");
     header("Access-Control-Allow-Credentials: true");
     exit;
 }
@@ -164,6 +165,7 @@ curl_close($ch);
 header("Access-Control-Allow-Origin: $origin");
 header("Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE");
 header("Access-Control-Allow-Headers: *");
+header("Access-Control-Expose-Headers: X-GitHub-SSO");
 header("Access-Control-Allow-Credentials: true");
 header("Content-Type: $responseContentType");
 http_response_code($httpCode);

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -586,12 +586,19 @@ a:hover {
   flex: 1;
 }
 
+.help-text {
+  display: block;
+  margin-top: 5px;
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
 .btn-authorize {
   background-color: #238636;
   color: #ffffff !important;
   border-color: rgba(240, 246, 252, 0.1);
   text-decoration: none !important;
-  margin-left: 0;
+  margin-left: 10px;
   display: inline-block;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -216,6 +216,9 @@ function App() {
                   ssoUrl = match[1];
                 }
               }
+              if (!ssoUrl) {
+                ssoUrl = 'https://github.com/settings/tokens';
+              }
             }
             console.error(`Error for ${repo}: ${message}`);
             onRepoError?.(repo, { message, ssoUrl });
@@ -803,6 +806,9 @@ function App() {
               onChange={(e) => setDraftGhToken(e.target.value)}
               placeholder="ghp_..."
             />
+            <small className="help-text">
+              If you are using organization repositories, you may need to <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer">Configure SAML SSO</a> for your token.
+            </small>
           </div>
           <div className="settings-group">
             <label htmlFor="jules-token">Jules API Token:</label>

--- a/web/tests/sso.spec.ts
+++ b/web/tests/sso.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('SAML SSO Troubleshooting', () => {
+  test('should show Authorize button when 403 occurs even without X-GitHub-SSO header (FIXED)', async ({ page }) => {
+    // Mock GitHub Issues API to return 403
+    await page.route('**/repos/chatelao/private-repo/issues?state=all*', async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Forbidden' }),
+        headers: {}
+      });
+    });
+
+    // Set repo history to include the failing repo
+    await page.addInitScript(() => {
+        window.localStorage.setItem('gh_repos', JSON.stringify(['chatelao/private-repo']));
+        window.localStorage.setItem('github_token', 'mock-token');
+    });
+
+    await page.goto('/?test=true');
+
+    const errorItem = page.locator('.repo-error-item').filter({ hasText: 'chatelao/private-repo' });
+    await expect(errorItem).toBeVisible();
+    // THE FIX: Authorize button should now be visible even if X-GitHub-SSO header was missing
+    await expect(errorItem.locator('.btn-authorize')).toBeVisible();
+    await expect(errorItem.locator('.btn-authorize')).toHaveAttribute('href', 'https://github.com/settings/tokens');
+  });
+
+  test('should show Authorize button when 403 occurs with X-GitHub-SSO header', async ({ page }) => {
+    await page.route('**/repos/chatelao/sso-repo/issues?state=all*', async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'SAML SSO required' }),
+        headers: {
+            'X-GitHub-SSO': 'url=https://github.com/orgs/chatelao/sso?authorization_request=abc',
+            'Access-Control-Expose-Headers': 'X-GitHub-SSO'
+        }
+      });
+    });
+
+    await page.addInitScript(() => {
+        window.localStorage.setItem('gh_repos', JSON.stringify(['chatelao/sso-repo']));
+        window.localStorage.setItem('github_token', 'mock-token');
+    });
+
+    await page.goto('/?test=true');
+
+    const errorItem = page.locator('.repo-error-item').filter({ hasText: 'chatelao/sso-repo' });
+    await expect(errorItem).toBeVisible();
+    await expect(errorItem.locator('.btn-authorize')).toBeVisible();
+    await expect(errorItem.locator('.btn-authorize')).toHaveAttribute('href', 'https://github.com/orgs/chatelao/sso?authorization_request=abc');
+  });
+
+  test('should have SAML SSO link in settings (FIXED)', async ({ page }) => {
+    await page.goto('/?test=true');
+    await page.click('.settings-toggle');
+    await expect(page.locator('.settings-panel')).toBeVisible();
+    // Now there should be a mention of SSO in settings
+    await expect(page.locator('.settings-panel')).toContainText('Configure SAML SSO');
+    const ssoLink = page.locator('.settings-panel a', { hasText: 'Configure SAML SSO' });
+    await expect(ssoLink).toBeVisible();
+    await expect(ssoLink).toHaveAttribute('href', 'https://github.com/settings/tokens');
+  });
+});


### PR DESCRIPTION
This PR addresses the issue where users were unable to easily authorize their GitHub PAT for SAML SSO, causing organization repositories to fail to load.

Key changes:
1.  **Settings UI**: Added a direct link to GitHub token settings under the PAT field for proactive SSO configuration.
2.  **Error Handling**: The dashboard now identifies 403 Forbidden errors and provides an "Authorize" button. If the `X-GitHub-SSO` header is provided by GitHub (and exposed by the proxy), it links directly to the authorization request; otherwise, it links to the general GitHub token management page.
3.  **Proxy Documentation**: Updated `CORS_PROXY.md` to include `Access-Control-Expose-Headers: X-GitHub-SSO` in the recommended PHP script, ensuring browsers can read the authorization URL.
4.  **Tests**: Introduced `web/tests/sso.spec.ts` which mocks various 403 scenarios to ensure the troubleshooting UI remains functional.
5.  **Styling**: Added `.help-text` and adjusted `.btn-authorize` margins in `App.css` for better UI layout.

Fixes #203

---
*PR created automatically by Jules for task [11573730661549799121](https://jules.google.com/task/11573730661549799121) started by @chatelao*