### PR TITLE
Add setting to ignore failing repository accesses

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -103,6 +103,22 @@ h1 {
   box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.3);
 }
 
+.checkbox-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.checkbox-group input {
+  width: auto;
+  margin: 0;
+}
+
+.checkbox-group label {
+  margin: 0;
+  cursor: pointer;
+}
+
 .settings-actions {
   display: flex;
   gap: 12px;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,9 +76,11 @@ function App() {
   const [ghToken, setGhToken] = useState<string>(localStorage.getItem('github_token') || '');
   const [julesToken, setJulesToken] = useState<string>(localStorage.getItem('jules_token') || '');
   const [julesApiBase, setJulesApiBase] = useState<string>(localStorage.getItem('jules_api_base') || DEFAULT_JULES_API_BASE);
+  const [ignoreFailingRepos, setIgnoreFailingRepos] = useState<boolean>(localStorage.getItem('ignore_failing_repos') === 'true');
   const [draftGhToken, setDraftGhToken] = useState<string>(ghToken);
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [draftJulesApiBase, setDraftJulesApiBase] = useState<string>(julesApiBase);
+  const [draftIgnoreFailingRepos, setDraftIgnoreFailingRepos] = useState<boolean>(ignoreFailingRepos);
   const [showSettings, setShowSettings] = useState<boolean>(false);
 
   const [repoHistory, setRepoHistory] = useState<string[]>(() => {
@@ -123,8 +125,9 @@ function App() {
       setDraftJulesToken(julesToken);
       setDraftJulesApiBase(julesApiBase);
       setDraftRepoHistory(repoHistory.join(', '));
+      setDraftIgnoreFailingRepos(ignoreFailingRepos);
     }
-  }, [showSettings, ghToken, julesToken, julesApiBase, repoHistory]);
+  }, [showSettings, ghToken, julesToken, julesApiBase, repoHistory, ignoreFailingRepos]);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -344,10 +347,12 @@ function App() {
     localStorage.setItem('jules_token', draftJulesToken);
     localStorage.setItem('jules_api_base', draftJulesApiBase);
     localStorage.setItem('gh_repos', JSON.stringify(newRepos));
+    localStorage.setItem('ignore_failing_repos', String(draftIgnoreFailingRepos));
     setGhToken(draftGhToken);
     setJulesToken(draftJulesToken);
     setJulesApiBase(draftJulesApiBase);
     setRepoHistory(newRepos);
+    setIgnoreFailingRepos(draftIgnoreFailingRepos);
     setShowSettings(false);
     setRefreshTrigger(prev => prev + 1);
   };
@@ -423,14 +428,17 @@ function App() {
     localStorage.removeItem('jules_token');
     localStorage.removeItem('jules_api_base');
     localStorage.removeItem('gh_repos');
+    localStorage.removeItem('ignore_failing_repos');
     setGhToken('');
     setJulesToken('');
     setJulesApiBase(DEFAULT_JULES_API_BASE);
     setRepoHistory([]);
+    setIgnoreFailingRepos(false);
     setDraftGhToken('');
     setDraftJulesToken('');
     setDraftJulesApiBase(DEFAULT_JULES_API_BASE);
     setDraftRepoHistory('');
+    setDraftIgnoreFailingRepos(false);
     setShowSettings(false);
     setRefreshTrigger(prev => prev + 1);
   };
@@ -843,6 +851,15 @@ function App() {
               placeholder="owner/repo, owner2/repo2 (leave empty to track all your repos)"
             />
           </div>
+          <div className="settings-group checkbox-group">
+            <input
+              id="ignore-failing-repos"
+              type="checkbox"
+              checked={draftIgnoreFailingRepos}
+              onChange={(e) => setDraftIgnoreFailingRepos(e.target.checked)}
+            />
+            <label htmlFor="ignore-failing-repos">Ignore failing repository accesses</label>
+          </div>
           <div className="settings-actions">
             <button className="btn-save" onClick={handleSaveSettings}>Save & Reload</button>
             <button className="btn-clear" onClick={handleClearSettings}>Clear All</button>
@@ -851,7 +868,7 @@ function App() {
         </section>
       )}
 
-      {Object.keys(repoErrors).length > 0 && (
+      {Object.keys(repoErrors).length > 0 && !ignoreFailingRepos && (
         <div className="repo-error-banner">
           <div className="repo-error-header">
             <strong>Warning: Some repositories failed to load</strong>


### PR DESCRIPTION
Implemented a new setting "Ignore failing repository accesses" in the dashboard.
- Added `ignoreFailingRepos` state and persisted it to `localStorage` as `ignore_failing_repos`.
- Added a checkbox in the Settings panel to toggle this setting.
- Updated the UI to hide the `repo-error-banner` when the setting is enabled.
- Added CSS styles for checkbox alignment in the settings group.
- Verified changes with Playwright tests and visual inspection via screenshots.

Fixes #205

---
*PR created automatically by Jules for task [9530788558419270687](https://jules.google.com/task/9530788558419270687) started by @chatelao*