### PR TITLE
Update GH Pages Deployment Triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - main-new
+      - jules-*
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
I have updated the GitHub Actions deployment workflow (`.github/workflows/deploy.yml`) to include `main-new` and `jules-*` in the list of branches that trigger a deployment to GitHub Pages. 

This was necessary because the project's primary branch is `main-new`, but the workflow was previously only configured to trigger on `main`. By adding these branches, any push (including the one for this change) will now correctly trigger a rebuild and update of the hosted dashboard.

Key actions taken:
- Verified that the web application builds correctly locally (`npm run build` in the `web/` directory).
- Modified `.github/workflows/deploy.yml` to include the additional branch triggers.
- Cleaned up accidental staging of `node_modules` files during the build process.
- Verified the workflow changes and ensured core tests pass.

Fixes #207

---
*PR created automatically by Jules for task [15260032246470234028](https://jules.google.com/task/15260032246470234028) started by @chatelao*