### PR TITLE
Rebuild GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - main-new
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This change updates the GitHub Actions deployment workflow to include the `main-new` branch in the push triggers. This ensures that pushes to `main-new` (the repository's default branch) will correctly trigger the build and deployment of the AI Dashboard to GitHub Pages.

Fixes #209

---
*PR created automatically by Jules for task [1974133795267937718](https://jules.google.com/task/1974133795267937718) started by @chatelao*