### PR TITLE
Add interactive tooltips for PR summaries and detailed file stats

### DIFF
--- a/test/pr_files.spec.ts
+++ b/test/pr_files.spec.ts
@@ -74,6 +74,8 @@ test('displays PR file count and extensions', async ({ page }) => {
   const prRow = page.locator('tr', { hasText: 'PR with files' });
   await expect(prRow).toBeVisible();
 
-  // The text should contain "(3 files, .ts, .tsx)"
-  await expect(prRow).toContainText('(3 files, .ts, .tsx)');
+  // The text should contain "3 files" and the extensions
+  await expect(prRow).toContainText('3 files');
+  await expect(prRow).toContainText('.ts');
+  await expect(prRow).toContainText('.tsx');
 });

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -538,3 +538,75 @@ a:hover {
 .btn-merge:hover:not(:disabled) {
   background-color: #2ea043;
 }
+
+/* Tooltip container */
+.tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+}
+
+/* Tooltip text */
+.tooltip .tooltip-text {
+  visibility: hidden;
+  width: max-content;
+  max-width: 400px;
+  background-color: #161b22;
+  color: #c9d1d9;
+  text-align: left;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 8px 12px;
+  position: absolute;
+  z-index: 100;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.2s;
+  box-shadow: 0 8px 24px rgba(1,4,9,0.2);
+  font-size: 0.8rem;
+  font-weight: normal;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Tooltip arrow */
+.tooltip .tooltip-text::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #30363d transparent transparent transparent;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+.additions-text {
+  color: #3fb950;
+}
+
+.deletions-text {
+  color: #f85149;
+}
+
+.tooltip-stats {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+
+.tooltip-filenames {
+  display: block;
+  margin-top: 4px;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 0.75rem;
+  opacity: 0.9;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,9 @@ interface IssueWithJulesStatus extends GitHubIssue {
   actionLoading?: boolean;
   prFilesCount?: number;
   prFileExtensions?: string[];
+  prAdditions?: number;
+  prDeletions?: number;
+  prFileStats?: Record<string, { filenames: string[], additions: number, deletions: number }>;
 }
 
 const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1alpha';
@@ -128,6 +131,64 @@ function App() {
 
   const formatJulesStatus = (status: string) => {
     return status === 'in-progress' ? 'InProgress' : status.replace(/-/g, ' ');
+  };
+
+  const renderFileInfo = (item: IssueWithJulesStatus) => {
+    if (item.prFilesCount === undefined) return null;
+    return (
+      <span className="pr-files-info">
+        {' '}
+        (
+        <span className="tooltip">
+          {item.prFilesCount} {item.prFilesCount === 1 ? 'file' : 'files'}
+          {(item.prAdditions !== undefined || item.prDeletions !== undefined) && (
+            <span className="tooltip-text">
+              Total: <span className="additions-text">+{item.prAdditions || 0}</span>{' '}
+              <span className="deletions-text">-{item.prDeletions || 0}</span>
+            </span>
+          )}
+        </span>
+        {item.prFileExtensions && item.prFileExtensions.length > 0 && (
+          <>
+            {', '}
+            {item.prFileExtensions.map((ext, idx) => (
+              <span key={ext}>
+                <span className="tooltip">
+                  {ext}
+                  {item.prFileStats && item.prFileStats[ext] && (
+                    <span className="tooltip-text">
+                      <span className="tooltip-stats">
+                        <span className="additions-text">+{item.prFileStats[ext].additions}</span>{' '}
+                        <span className="deletions-text">-{item.prFileStats[ext].deletions}</span>
+                      </span>
+                      <div className="tooltip-filenames">
+                        {item.prFileStats[ext].filenames.join('\n')}
+                      </div>
+                    </span>
+                  )}
+                </span>
+                {idx < (item.prFileExtensions?.length || 0) - 1 ? ', ' : ''}
+              </span>
+            ))}
+          </>
+        )}
+        )
+      </span>
+    );
+  };
+
+  const renderPRNumberTooltip = (item: IssueWithJulesStatus, includeLabel: boolean = true) => {
+    return (
+      <span className="tooltip">
+        <span className="pr-number">{includeLabel ? 'PR ' : ''}#{item.number}:</span>
+        {' '}
+        {item.body && (
+          <span className="tooltip-text">
+            {item.body.length > 500 ? item.body.substring(0, 500) + '...' : item.body}
+          </span>
+        )}
+      </span>
+    );
   };
 
   const fetchRawIssues = async (repo: string, filterState: string, headers: HeadersInit): Promise<GitHubIssue[]> => {
@@ -601,6 +662,8 @@ function App() {
                     const prDetail: any = await prResponse.json();
                     target.mergeable = prDetail.mergeable;
                     target.mergeable_state = prDetail.mergeable_state;
+                    target.prAdditions = prDetail.additions;
+                    target.prDeletions = prDetail.deletions;
 
                     // Fetch PR files to get count and extensions
                     try {
@@ -611,14 +674,19 @@ function App() {
                       if (filesResponse.ok) {
                         const filesData: any[] = await filesResponse.json();
                         target.prFilesCount = filesData.length;
-                        const extensions = new Set<string>();
+                        const stats: Record<string, { filenames: string[], additions: number, deletions: number }> = {};
                         filesData.forEach(file => {
                           const parts = file.filename.split('.');
-                          if (parts.length > 1) {
-                            extensions.add(`.${parts.pop()}`);
+                          const ext = parts.length > 1 ? `.${parts.pop()}` : 'no-ext';
+                          if (!stats[ext]) {
+                            stats[ext] = { filenames: [], additions: 0, deletions: 0 };
                           }
+                          stats[ext].filenames.push(file.filename);
+                          stats[ext].additions += (file.additions || 0);
+                          stats[ext].deletions += (file.deletions || 0);
                         });
-                        target.prFileExtensions = Array.from(extensions);
+                        target.prFileStats = stats;
+                        target.prFileExtensions = Object.keys(stats);
                       }
                     } catch (err) {
                       console.error(`Failed to fetch files for PR #${target.number}`, err);
@@ -819,23 +887,16 @@ function App() {
                             <span className="repo-tag">[{issue.repository.full_name.split('/')[1]}]</span>
                           </a>{' '}
                           <a href={issue.html_url} target="_blank" rel="noopener noreferrer">
+                            {issue.pull_request && renderPRNumberTooltip(issue, false)}
                             {issue.title}
-                            {issue.prFilesCount !== undefined && (
-                              <span className="pr-files-info">
-                                {' '}({issue.prFilesCount} {issue.prFilesCount === 1 ? 'file' : 'files'}{issue.prFileExtensions && issue.prFileExtensions.length > 0 ? `, ${issue.prFileExtensions.join(', ')}` : ''})
-                              </span>
-                            )}
+                            {renderFileInfo(issue)}
                           </a>
                         </div>
                         {issue.linkedPRs && issue.linkedPRs.map(pr => (
                           <div key={pr.id} className="subtitle">
                             <a href={pr.html_url} target="_blank" rel="noopener noreferrer">
-                              <span className="pr-number">PR #{pr.number}:</span> {pr.title}
-                              {pr.prFilesCount !== undefined && (
-                                <span className="pr-files-info">
-                                  {' '}({pr.prFilesCount} {pr.prFilesCount === 1 ? 'file' : 'files'}{pr.prFileExtensions && pr.prFileExtensions.length > 0 ? `, ${pr.prFileExtensions.join(', ')}` : ''})
-                                </span>
-                              )}
+                              {renderPRNumberTooltip(pr)} {pr.title}
+                              {renderFileInfo(pr)}
                             </a>
                           </div>
                         ))}

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -94,7 +94,8 @@ test.describe('Dashboard Consolidation', () => {
     // Verify Issue 101 exists and has PR 102 as subtitle
     const issueRow = page.locator('tbody tr').filter({ hasText: 'Fix a bug' }).first();
     await expect(issueRow).toBeVisible();
-    await expect(issueRow.locator('td[data-label="Title"] .subtitle').first()).toContainText('PR #102: A linked PR');
+    await expect(issueRow.locator('td[data-label="Title"] .subtitle').first()).toContainText('PR #102:');
+    await expect(issueRow.locator('td[data-label="Title"] .subtitle').first()).toContainText('A linked PR');
 
     // Verify Issue 101's row has the green PR status icon (from linked PR 102)
     await expect(issueRow.locator('.pr-icon-green').first()).toBeVisible();


### PR DESCRIPTION
This change enhances the dashboard by adding informative tooltips. 

Key improvements:
- **PR Summary Tooltips**: Hovering over a PR ID now shows the first 500 characters of the PR description.
- **Detailed File Stats**: Hovering over the file count (e.g., "5 files") shows the total additions and deletions for the PR.
- **Extension-Specific Tooltips**: Hovering over an extension (e.g., ".tsx") displays a list of affected filenames and the specific additions/deletions for that extension.

Technical details:
- Added `prAdditions`, `prDeletions`, and `prFileStats` to the `IssueWithJulesStatus` interface.
- Updated the background enrichment process to capture and aggregate these statistics from the GitHub API.
- Introduced a reusable CSS tooltip system in `App.css`.
- Refactored `App.tsx` with helper functions (`renderFileInfo`, `renderPRNumberTooltip`) to ensure consistent tooltip rendering across the dashboard.
- Updated existing Playwright tests to reflect the new UI structure.

Fixes #213

---
*PR created automatically by Jules for task [17714474192054945869](https://jules.google.com/task/17714474192054945869) started by @chatelao*