### PR TITLE
Add button to duplicate issues

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -503,6 +503,29 @@ a:hover {
   }
 }
 
+.btn-duplicate {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin-right: 8px;
+  background: none;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  vertical-align: middle;
+  transition: color 0.2s;
+}
+
+.btn-duplicate:hover {
+  color: #58a6ff;
+}
+
+.btn-duplicate:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .btn-action {
   padding: 4px 8px;
   font-size: 0.75rem;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -389,6 +389,42 @@ function App() {
     }
   };
 
+  const handleDuplicateIssue = async (issue: IssueWithJulesStatus) => {
+    if (!ghToken) {
+      alert('GitHub token is required to duplicate issues.');
+      return;
+    }
+    if (!confirm(`Are you sure you want to duplicate issue #${issue.number} in ${issue.repository.full_name}?`)) return;
+
+    updateActionLoading(issue.id, true);
+    try {
+      const response = await fetch(`https://api.github.com/repos/${issue.repository.full_name}/issues`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `token ${ghToken}`,
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        },
+        body: JSON.stringify({
+          title: issue.title,
+          body: issue.body,
+          labels: issue.labels.map(l => l.name)
+        })
+      });
+
+      if (response.ok) {
+        setRefreshTrigger(prev => prev + 1);
+      } else {
+        const data = await response.json();
+        alert(`Failed to duplicate issue: ${data.message || response.statusText}`);
+      }
+    } catch (err) {
+      alert(`Error duplicating issue: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      updateActionLoading(issue.id, false);
+    }
+  };
+
   const handleClearSettings = () => {
     localStorage.removeItem('github_token');
     localStorage.removeItem('jules_token');
@@ -879,6 +915,19 @@ function App() {
                     <td data-label="Title">
                       <div className="title-container">
                         <div className="issue-title-line">
+                          <button
+                            className="btn-duplicate"
+                            onClick={() => handleDuplicateIssue(issue)}
+                            disabled={issue.actionLoading}
+                            title="Duplicate issue"
+                          >
+                            {issue.actionLoading ? '...' : (
+                              <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+                                <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+                                <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+                              </svg>
+                            )}
+                          </button>
                           <a
                             href={`https://github.com/${issue.repository.full_name}/issues/new?labels=Jules`}
                             target="_blank"
@@ -894,6 +943,19 @@ function App() {
                         </div>
                         {issue.linkedPRs && issue.linkedPRs.map(pr => (
                           <div key={pr.id} className="subtitle">
+                            <button
+                              className="btn-duplicate"
+                              onClick={() => handleDuplicateIssue(pr)}
+                              disabled={pr.actionLoading}
+                              title="Duplicate issue"
+                            >
+                              {pr.actionLoading ? '...' : (
+                                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+                                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+                                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+                                </svg>
+                              )}
+                            </button>
                             <a href={pr.html_url} target="_blank" rel="noopener noreferrer">
                               {renderPRNumberTooltip(pr)} {pr.title}
                               {renderFileInfo(pr)}


### PR DESCRIPTION
This change adds a "Duplicate" button (represented by a copy-paste icon) next to each issue and linked PR in the dashboard. When clicked, it prompts the user for confirmation and then creates a new issue in the same repository with the same title, body, and labels as the original. This is useful for quickly creating similar tasks or re-running Jules on a fresh issue.

Fixes #215

---
*PR created automatically by Jules for task [10855828763637285440](https://jules.google.com/task/10855828763637285440) started by @chatelao*