### PR TITLE
Remove duplicate icon from Pull Requests

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -915,19 +915,21 @@ function App() {
                     <td data-label="Title">
                       <div className="title-container">
                         <div className="issue-title-line">
-                          <button
-                            className="btn-duplicate"
-                            onClick={() => handleDuplicateIssue(issue)}
-                            disabled={issue.actionLoading}
-                            title="Duplicate issue"
-                          >
-                            {issue.actionLoading ? '...' : (
-                              <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-                                <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
-                                <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-                              </svg>
-                            )}
-                          </button>
+                          {!issue.pull_request && (
+                            <button
+                              className="btn-duplicate"
+                              onClick={() => handleDuplicateIssue(issue)}
+                              disabled={issue.actionLoading}
+                              title="Duplicate issue"
+                            >
+                              {issue.actionLoading ? '...' : (
+                                <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+                                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+                                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+                                </svg>
+                              )}
+                            </button>
+                          )}
                           <a
                             href={`https://github.com/${issue.repository.full_name}/issues/new?labels=Jules`}
                             target="_blank"
@@ -943,19 +945,6 @@ function App() {
                         </div>
                         {issue.linkedPRs && issue.linkedPRs.map(pr => (
                           <div key={pr.id} className="subtitle">
-                            <button
-                              className="btn-duplicate"
-                              onClick={() => handleDuplicateIssue(pr)}
-                              disabled={pr.actionLoading}
-                              title="Duplicate issue"
-                            >
-                              {pr.actionLoading ? '...' : (
-                                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
-                                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
-                                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-                                </svg>
-                              )}
-                            </button>
                             <a href={pr.html_url} target="_blank" rel="noopener noreferrer">
                               {renderPRNumberTooltip(pr)} {pr.title}
                               {renderFileInfo(pr)}


### PR DESCRIPTION
This PR removes the duplicate button icon from in front of Pull Requests in the dashboard UI. The icon is now only displayed for Issues.

Key changes:
- Modified `web/src/App.tsx` to conditionally render the `.btn-duplicate` button only when `!issue.pull_request`.
- Removed the duplicate button from the `linkedPRs` mapping loop to prevent it from appearing in subtitles.
- Verified that existing tests pass and confirmed the visual change via screenshot verification.

Fixes #220

---
*PR created automatically by Jules for task [3446454624162998937](https://jules.google.com/task/3446454624162998937) started by @chatelao*