### PR TITLE
Color filenames in PR tooltips by change percentages

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -644,3 +644,7 @@ a:hover {
   font-size: 0.75rem;
   opacity: 0.9;
 }
+
+.tooltip-filename-row {
+  white-space: nowrap;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,7 +44,18 @@ interface IssueWithJulesStatus extends GitHubIssue {
   prFileExtensions?: string[];
   prAdditions?: number;
   prDeletions?: number;
-  prFileStats?: Record<string, { filenames: string[], additions: number, deletions: number }>;
+  prFileStats?: Record<string, {
+    filenames: string[],
+    additions: number,
+    deletions: number,
+    details: {
+      name: string,
+      additions: number,
+      deletions: number,
+      totalLines: number,
+      status: string
+    }[]
+  }>;
 }
 
 const DEFAULT_JULES_API_BASE = 'https://jules.googleapis.com/v1alpha';
@@ -133,6 +144,99 @@ function App() {
     return status === 'in-progress' ? 'InProgress' : status.replace(/-/g, ' ');
   };
 
+  const renderColoredFilename = (name: string, additions: number, deletions: number, totalLines: number, status: string) => {
+    const L = name.length;
+    if (L === 0) return null;
+
+    let A = additions;
+    let D = deletions;
+    let U = 0;
+
+    if (status === 'added') {
+      U = 0;
+      D = 0;
+    } else if (status === 'removed') {
+      U = 0;
+      A = 0;
+    } else {
+      U = Math.max(0, totalLines - additions);
+    }
+
+    const relevantTotal = A + D + U;
+    if (relevantTotal === 0) return <span className="text-muted">{name}</span>;
+
+    let cA = Math.floor((A / relevantTotal) * L);
+    let cD = Math.floor((D / relevantTotal) * L);
+    let cU = Math.floor((U / relevantTotal) * L);
+
+    // Apply minimums: round >0.0 = 1 letter colored, <100 = 1 letter grey
+    if (A > 0 && cA === 0) cA = 1;
+    if (D > 0 && cD === 0) cD = 1;
+    if (U > 0 && cU === 0) cU = 1;
+
+    // Adjust to match L
+    let currentSum = cA + cD + cU;
+
+    if (currentSum > L) {
+      // Reduce from the largest ones that are above their minimum
+      const counts = [
+        { key: 'U', val: cU, min: U > 0 ? 1 : 0 },
+        { key: 'A', val: cA, min: A > 0 ? 1 : 0 },
+        { key: 'D', val: cD, min: D > 0 ? 1 : 0 }
+      ];
+      while (currentSum > L) {
+        counts.sort((a, b) => b.val - a.val);
+        let reduced = false;
+        for (const count of counts) {
+          if (count.val > count.min) {
+            count.val--;
+            currentSum--;
+            reduced = true;
+            break;
+          }
+        }
+        if (!reduced) break;
+      }
+      cU = counts.find(c => c.key === 'U')!.val;
+      cA = counts.find(c => c.key === 'A')!.val;
+      cD = counts.find(c => c.key === 'D')!.val;
+    }
+
+    if (currentSum < L) {
+      // Increase the largest ones
+      const counts = [
+        { key: 'U', val: cU, weight: U },
+        { key: 'A', val: cA, weight: A },
+        { key: 'D', val: cD, weight: D }
+      ];
+      while (currentSum < L) {
+        counts.sort((a, b) => b.weight - a.weight);
+        counts[0].val++;
+        currentSum++;
+      }
+      cU = counts.find(c => c.key === 'U')!.val;
+      cA = counts.find(c => c.key === 'A')!.val;
+      cD = counts.find(c => c.key === 'D')!.val;
+    }
+
+    const parts = [];
+    let start = 0;
+    if (cA > 0) {
+      parts.push(<span key="a" className="additions-text">{name.substring(start, start + cA)}</span>);
+      start += cA;
+    }
+    if (cD > 0) {
+      parts.push(<span key="d" className="deletions-text">{name.substring(start, start + cD)}</span>);
+      start += cD;
+    }
+    if (cU > 0) {
+      parts.push(<span key="u" className="text-muted">{name.substring(start, start + cU)}</span>);
+      start += cU;
+    }
+
+    return <>{parts}</>;
+  };
+
   const renderFileInfo = (item: IssueWithJulesStatus) => {
     if (item.prFilesCount === undefined) return null;
     return (
@@ -162,7 +266,11 @@ function App() {
                         <span className="deletions-text">-{item.prFileStats[ext].deletions}</span>
                       </span>
                       <div className="tooltip-filenames">
-                        {item.prFileStats[ext].filenames.join('\n')}
+                        {item.prFileStats[ext].details.map((detail, dIdx) => (
+                          <div key={dIdx} className="tooltip-filename-row">
+                            {renderColoredFilename(detail.name, detail.additions, detail.deletions, detail.totalLines, detail.status)}
+                          </div>
+                        ))}
                       </div>
                     </span>
                   )}
@@ -710,17 +818,55 @@ function App() {
                       if (filesResponse.ok) {
                         const filesData: any[] = await filesResponse.json();
                         target.prFilesCount = filesData.length;
-                        const stats: Record<string, { filenames: string[], additions: number, deletions: number }> = {};
-                        filesData.forEach(file => {
+                        const stats: Record<string, {
+                          filenames: string[],
+                          additions: number,
+                          deletions: number,
+                          details: {
+                            name: string,
+                            additions: number,
+                            deletions: number,
+                            totalLines: number,
+                            status: string
+                          }[]
+                        }> = {};
+
+                        await Promise.all(filesData.map(async (file) => {
                           const parts = file.filename.split('.');
                           const ext = parts.length > 1 ? `.${parts.pop()}` : 'no-ext';
                           if (!stats[ext]) {
-                            stats[ext] = { filenames: [], additions: 0, deletions: 0 };
+                            stats[ext] = { filenames: [], additions: 0, deletions: 0, details: [] };
                           }
                           stats[ext].filenames.push(file.filename);
                           stats[ext].additions += (file.additions || 0);
                           stats[ext].deletions += (file.deletions || 0);
-                        });
+
+                          let totalLines = 0;
+                          if (file.status === 'added') {
+                            totalLines = file.additions || 0;
+                          } else if (file.status === 'removed') {
+                            totalLines = file.deletions || 0;
+                          } else if (file.raw_url) {
+                            try {
+                              const rawResponse = await fetch(file.raw_url, { headers });
+                              if (rawResponse.ok) {
+                                const content = await rawResponse.text();
+                                totalLines = content.split('\n').length;
+                              }
+                            } catch (e) {
+                              console.error(`Failed to fetch raw content for ${file.filename}`, e);
+                            }
+                          }
+
+                          stats[ext].details.push({
+                            name: file.filename,
+                            additions: file.additions || 0,
+                            deletions: file.deletions || 0,
+                            totalLines,
+                            status: file.status
+                          });
+                        }));
+
                         target.prFileStats = stats;
                         target.prFileExtensions = Object.keys(stats);
                       }

--- a/web/tests/pr_coloring.spec.ts
+++ b/web/tests/pr_coloring.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('PR File Coloring', () => {
+  test('should color filenames according to change percentages', async ({ page }) => {
+    // Set mock tokens
+    await page.addInitScript(() => {
+      window.localStorage.setItem('github_token', 'mock-gh-token');
+      (window as any).isTest = true;
+    });
+
+    // Mock GitHub Issues API
+    await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 1,
+            number: 101,
+            title: 'PR with colored files',
+            state: 'open',
+            html_url: 'https://github.com/chatelao/AI-Dashboard/pull/101',
+            body: 'Some PR',
+            repository: { full_name: 'chatelao/AI-Dashboard' },
+            assignee: null,
+            labels: [],
+            updated_at: new Date().toISOString(),
+            pull_request: {
+              url: 'https://api.github.com/repos/chatelao/AI-Dashboard/pulls/101',
+              html_url: 'https://github.com/chatelao/AI-Dashboard/pull/101'
+            }
+          }
+        ])
+      });
+    });
+
+    // Mock PR Detail API
+    await page.route('**/repos/chatelao/AI-Dashboard/pulls/101', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          number: 101,
+          mergeable: true,
+          mergeable_state: 'clean',
+          head: { sha: 'mock-sha' },
+          additions: 100,
+          deletions: 50
+        })
+      });
+    });
+
+    // Mock PR Files API
+    await page.route('**/repos/chatelao/AI-Dashboard/pulls/101/files', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            filename: 'new_file.ts',
+            status: 'added',
+            additions: 100,
+            deletions: 0,
+            raw_url: 'https://github.com/raw/new_file.ts'
+          },
+          {
+            filename: 'deleted_file.ts',
+            status: 'removed',
+            additions: 0,
+            deletions: 50,
+            raw_url: 'https://github.com/raw/deleted_file.ts'
+          },
+          {
+            filename: 'modified_file.ts',
+            status: 'modified',
+            additions: 10,
+            deletions: 10,
+            raw_url: 'https://github.com/raw/modified_file.ts'
+          }
+        ])
+      });
+    });
+
+    // Mock Raw File Content for modified file
+    await page.route('https://github.com/raw/modified_file.ts', async (route) => {
+      // 10 additions, 100 total lines (90 unchanged)
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/plain',
+        body: 'line\n'.repeat(100)
+      });
+    });
+
+    // Mock Check Runs API
+    await page.route('**/repos/chatelao/AI-Dashboard/commits/mock-sha/check-runs', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ total_count: 0, check_runs: [] })
+      });
+    });
+
+    await page.goto('/?test=true');
+
+    // Wait for the PR file count to appear
+    const prFilesInfo = page.locator('.pr-files-info');
+    await expect(prFilesInfo).toBeVisible();
+
+    // Hover over the .ts extension to see the tooltip
+    const tsExtension = page.locator('.tooltip', { hasText: '.ts' }).first();
+    await tsExtension.hover();
+
+    const tooltip = page.locator('.tooltip-text').last();
+    await expect(tooltip).toBeVisible();
+
+    // Check coloring for new_file.ts (100% added -> 100% green)
+    const newFileRow = tooltip.locator('.tooltip-filename-row', { hasText: 'new_file.ts' });
+    const greenPartNew = newFileRow.locator('.additions-text');
+    await expect(greenPartNew).toHaveText('new_file.ts');
+
+    // Check coloring for deleted_file.ts (100% removed -> 100% red)
+    const deletedFileRow = tooltip.locator('.tooltip-filename-row', { hasText: 'deleted_file.ts' });
+    const redPartDeleted = deletedFileRow.locator('.deletions-text');
+    await expect(redPartDeleted).toHaveText('deleted_file.ts');
+
+    // Check coloring for modified_file.ts
+    // filename length is 16
+    // additions: 10
+    // deletions: 10
+    // total lines: 100
+    // unchanged = 100 - 10 = 90
+    // relevantTotal = 10 + 10 + 90 = 110
+    // additions ratio: 10/110 * 16 = 1.45 -> 1 char
+    // deletions ratio: 10/110 * 16 = 1.45 -> 1 char
+    // unchanged ratio: 90/110 * 16 = 13.09 -> 13 chars
+    // total = 1 + 1 + 13 = 15. Adjustment will add 1 to largest weight (unchanged). -> 14 chars grey.
+    const modifiedFileRow = tooltip.locator('.tooltip-filename-row', { hasText: 'modified_file.ts' });
+    const greenPartMod = modifiedFileRow.locator('.additions-text');
+    const redPartMod = modifiedFileRow.locator('.deletions-text');
+    const greyPartMod = modifiedFileRow.locator('.text-muted');
+
+    await expect(greenPartMod).toHaveText(/^m/); // At least first letter green
+    await expect(redPartMod).toBeVisible();
+    await expect(greyPartMod).toBeVisible();
+  });
+});


### PR DESCRIPTION
This PR implements a new visualization for pull request file changes by coloring the filenames themselves in the extension tooltips based on the proportion of additions, deletions, and unchanged lines.

Key changes:
- **Proportional Coloring:** Filenames are now rendered as a sequence of colored segments (green, red, and grey) representing the breakdown of line changes.
- **Line Count Fetching:** During PR enrichment, the application now fetches raw file content for modified/renamed files from GitHub to determine the total number of lines, enabling accurate percentage calculation.
- **Rounding Rules:**
    - Any category with more than 0 lines gets at least one character colored (e.g., a single line change in a large file still highlights the first character).
    - Any file with unchanged lines (less than 100% change) retains at least one grey character.
- **UI Enhancements:** Added `renderColoredFilename` helper and updated `App.css` to handle non-wrapping filename rows.
- **Testing:** Introduced a new Playwright test suite `web/tests/pr_coloring.spec.ts` that mocks various PR file scenarios (added, deleted, modified) to verify the coloring and rounding logic.

Fixes #219

---
*PR created automatically by Jules for task [9868170767279298347](https://jules.google.com/task/9868170767279298347) started by @chatelao*