### PR TITLE
Update repo tag link to issues list

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1083,7 +1083,7 @@ function App() {
                             </button>
                           )}
                           <a
-                            href={`https://github.com/${issue.repository.full_name}/issues/new?labels=Jules`}
+                            href={`https://github.com/${issue.repository.full_name}/issues`}
                             target="_blank"
                             rel="noopener noreferrer"
                           >

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -108,10 +108,10 @@ test.describe('Dashboard Consolidation', () => {
     const rows = page.locator('tbody tr');
     await expect(rows).toHaveCount(2);
 
-    // Verify repository tag links to "new issue" page with Jules label
-    const repoTagLink = issueRow.locator('a[href*="/issues/new?labels=Jules"]');
+    // Verify repository tag links to the issues page
+    const repoTagLink = issueRow.locator('a[href$="/issues"]');
     await expect(repoTagLink).toBeVisible();
-    await expect(repoTagLink).toHaveAttribute('href', 'https://github.com/chatelao/AI-Dashboard/issues/new?labels=Jules');
+    await expect(repoTagLink).toHaveAttribute('href', 'https://github.com/chatelao/AI-Dashboard/issues');
   });
 
   test('should display Jules status for issues and linked PRs assigned to Jules', async ({ page }) => {


### PR DESCRIPTION
This change updates the link on the repository tags in the dashboard. Instead of linking to the "create new issue" page with the "Jules" label pre-selected, it now links to the general issues list for that repository.

Modified:
- `web/src/App.tsx`: Updated the URL template for the repository tag link.
- `web/tests/dashboard.spec.ts`: Updated the test assertion to match the new URL.

Fixes #225

---
*PR created automatically by Jules for task [3726055668541308027](https://jules.google.com/task/3726055668541308027) started by @chatelao*