### PR TITLE
Remove PR status icon and invert Merge/Update colors

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -543,23 +543,23 @@ a:hover {
 }
 
 .btn-update {
-  background-color: #21262d;
-  color: #c9d1d9;
-}
-
-.btn-update:hover:not(:disabled) {
-  background-color: #30363d;
-  border-color: #8b949e;
-}
-
-.btn-merge {
   background-color: #238636;
   color: #ffffff;
   border-color: rgba(240, 246, 252, 0.1);
 }
 
-.btn-merge:hover:not(:disabled) {
+.btn-update:hover:not(:disabled) {
   background-color: #2ea043;
+}
+
+.btn-merge {
+  background-color: #21262d;
+  color: #c9d1d9;
+}
+
+.btn-merge:hover:not(:disabled) {
+  background-color: #30363d;
+  border-color: #8b949e;
 }
 
 /* Tooltip container */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1119,19 +1119,6 @@ function App() {
                         )}
                         {issue.prStatus && (
                           <div className="pr-status-container">
-                            <svg
-                              className={`pr-icon pr-icon-${issue.prStatus.color}`}
-                              viewBox="0 0 16 16"
-                              version="1.1"
-                              width="16"
-                              height="16"
-                              aria-hidden="true"
-                            >
-                              <path
-                                fillRule="evenodd"
-                                d="M7.177 3.03a.75.75 0 11-1.354-.645 2.75 2.75 0 015.162 1.377 2.25 2.25 0 01-.89 4.113 2.25 2.25 0 011.655 2.175v.25a2.25 2.25 0 11-4.5 0v-.25c0-.97.615-1.798 1.48-2.122a2.75 2.75 0 00-1.553-4.898zM9 10.25a.75.75 0 00-1.5 0v.25a.75.75 0 001.5 0v-.25z"
-                              ></path>
-                            </svg>
                             <span className={`pr-label pr-label-${issue.prStatus.color}`}>
                               {issue.prStatus.label}
                             </span>
@@ -1162,19 +1149,6 @@ function App() {
                             </div>
                           ) : pr.prStatus && (
                             <div key={pr.id} className="pr-status-container subtitle">
-                              <svg
-                                className={`pr-icon pr-icon-${pr.prStatus.color}`}
-                                viewBox="0 0 16 16"
-                                version="1.1"
-                                width="16"
-                                height="16"
-                                aria-hidden="true"
-                              >
-                                <path
-                                  fillRule="evenodd"
-                                  d="M7.177 3.03a.75.75 0 11-1.354-.645 2.75 2.75 0 015.162 1.377 2.25 2.25 0 01-.89 4.113 2.25 2.25 0 011.655 2.175v.25a2.25 2.25 0 11-4.5 0v-.25c0-.97.615-1.798 1.48-2.122a2.75 2.75 0 00-1.553-4.898zM9 10.25a.75.75 0 00-1.5 0v.25a.75.75 0 001.5 0v-.25z"
-                                ></path>
-                              </svg>
                               <span className={`pr-label pr-label-${pr.prStatus.color}`}>
                                 {pr.prStatus.label}
                               </span>

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -97,8 +97,8 @@ test.describe('Dashboard Consolidation', () => {
     await expect(issueRow.locator('td[data-label="Title"] .subtitle').first()).toContainText('PR #102:');
     await expect(issueRow.locator('td[data-label="Title"] .subtitle').first()).toContainText('A linked PR');
 
-    // Verify Issue 101's row has the green PR status icon (from linked PR 102)
-    await expect(issueRow.locator('.pr-icon-green').first()).toBeVisible();
+    // Verify Issue 101's row has the green PR label (from linked PR 102)
+    await expect(issueRow.locator('.pr-label-green').first()).toBeVisible();
 
     // Verify PR 103 exists as a separate row (since it's not linked)
     const prRow = page.locator('tbody tr').filter({ hasText: 'Unlinked PR' }).first();


### PR DESCRIPTION
This change removes the lightning bolt icon from the PR status display and inverts the colors of the Update and Merge buttons in the dashboard. The Update button is now green, and the Merge button is now grey, as requested. Playwright tests have been updated and verified to ensure everything works as expected.

Fixes #227

---
*PR created automatically by Jules for task [101654210377204870](https://jules.google.com/task/101654210377204870) started by @chatelao*