### PR TITLE
Add Projects view with status squares per repository

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -147,6 +147,33 @@ h1 {
   background-color: #30363d;
 }
 
+.view-toggle {
+  display: flex;
+  background-color: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  overflow: hidden;
+  height: 38px;
+}
+
+.btn-toggle {
+  background: none;
+  border: none;
+  color: #c9d1d9;
+  padding: 0 16px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-toggle:hover {
+  background-color: #30363d;
+}
+
+.btn-toggle.active {
+  background-color: #1f6feb;
+  color: white;
+}
 
 .btn-refresh {
   padding: 8px 16px;
@@ -648,3 +675,58 @@ a:hover {
 .tooltip-filename-row {
   white-space: nowrap;
 }
+
+/* Project View Styles */
+.project-view {
+  background-color: #1a1a1a;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  text-align: left;
+}
+
+.project-line {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.project-line:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.project-name {
+  width: 200px;
+  font-weight: 600;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.project-squares {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.status-square {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: inline-block;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.status-square:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
+  z-index: 10;
+}
+
+.status-square.green { background-color: #238636; }
+.status-square.yellow { background-color: #d29922; }
+.status-square.red { background-color: #f85149; }
+.status-square.purple { background-color: #8957e5; }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,13 @@ function App() {
   const [draftJulesToken, setDraftJulesToken] = useState<string>(julesToken);
   const [draftJulesApiBase, setDraftJulesApiBase] = useState<string>(julesApiBase);
   const [showSettings, setShowSettings] = useState<boolean>(false);
+  const [viewMode, setViewMode] = useState<'list' | 'projects'>(
+    (localStorage.getItem('view_mode') as 'list' | 'projects') || 'list'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('view_mode', viewMode);
+  }, [viewMode]);
 
   const [repoHistory, setRepoHistory] = useState<string[]>(() => {
     const saved = localStorage.getItem('gh_repos');
@@ -142,6 +149,31 @@ function App() {
 
   const formatJulesStatus = (status: string) => {
     return status === 'in-progress' ? 'InProgress' : status.replace(/-/g, ' ');
+  };
+
+  const getIssueStatusColor = (issue: IssueWithJulesStatus): 'purple' | 'red' | 'yellow' | 'green' => {
+    if (issue.state === 'closed') return 'purple';
+
+    const julesStatus = issue.julesStatus;
+    const prStatus = issue.prStatus;
+
+    // Check linked PRs as well
+    const linkedPRs = issue.linkedPRs || [];
+    const allJulesStatuses = [julesStatus, ...linkedPRs.map(pr => pr.julesStatus)].filter(Boolean);
+    const allPRStatuses = [prStatus, ...linkedPRs.map(pr => pr.prStatus)].filter(Boolean);
+
+    if (allJulesStatuses.includes('failed') || allPRStatuses.some(ps => ps?.color === 'red')) {
+      return 'red';
+    }
+
+    if (
+      allJulesStatuses.some(s => ['in-progress', 'researching', 'planning', 'coding', 'testing'].includes(s!)) ||
+      allPRStatuses.some(ps => ps?.color === 'yellow')
+    ) {
+      return 'yellow';
+    }
+
+    return 'green';
   };
 
   const renderColoredFilename = (name: string, additions: number, deletions: number, totalLines: number, status: string) => {
@@ -978,6 +1010,20 @@ function App() {
             />
           </div>
           <div className="header-actions">
+            <div className="view-toggle">
+              <button
+                className={`btn-toggle ${viewMode === 'list' ? 'active' : ''}`}
+                onClick={() => setViewMode('list')}
+              >
+                List
+              </button>
+              <button
+                className={`btn-toggle ${viewMode === 'projects' ? 'active' : ''}`}
+                onClick={() => setViewMode('projects')}
+              >
+                Projects
+              </button>
+            </div>
             <button className="btn-refresh" onClick={() => setRefreshTrigger(prev => prev + 1)}>
               Refresh
             </button>
@@ -1050,7 +1096,66 @@ function App() {
         {loading && <p className="status-message">Loading issues...</p>}
         {error && <p className="status-message error">Error: {error}</p>}
 
-        {!loading && !error && (
+        {!loading && !error && viewMode === 'projects' && (
+          <div className="project-view">
+            {(() => {
+              const reposMap = new Map<string, IssueWithJulesStatus[]>();
+              issues.forEach(issue => {
+                const repoName = issue.repository.full_name;
+                if (!reposMap.has(repoName)) {
+                  reposMap.set(repoName, []);
+                }
+                reposMap.get(repoName)!.push(issue);
+              });
+
+              return Array.from(reposMap.entries()).map(([repoName, repoIssues]) => {
+                const openIssues = repoIssues.filter(i => i.state === 'open');
+                const closedIssues = repoIssues
+                  .filter(i => i.state === 'closed')
+                  .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+                  .slice(0, 3);
+
+                return (
+                  <div key={repoName} className="project-line">
+                    <div className="project-name">
+                      <a
+                        href={`https://github.com/${repoName}/issues`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {repoName.split('/')[1]}
+                      </a>
+                    </div>
+                    <div className="project-squares">
+                      {openIssues.map(issue => (
+                        <a
+                          key={issue.id}
+                          href={issue.julesUrl || issue.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`status-square ${getIssueStatusColor(issue)}`}
+                          title={`#${issue.number}: ${issue.title}`}
+                        ></a>
+                      ))}
+                      {closedIssues.map(issue => (
+                        <a
+                          key={issue.id}
+                          href={issue.julesUrl || issue.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`status-square ${getIssueStatusColor(issue)}`}
+                          title={`#${issue.number}: ${issue.title}`}
+                        ></a>
+                      ))}
+                    </div>
+                  </div>
+                );
+              });
+            })()}
+          </div>
+        )}
+
+        {!loading && !error && viewMode === 'list' && (
           <div className="table-container">
             <table>
               <thead>

--- a/web/tests/projects_view.spec.ts
+++ b/web/tests/projects_view.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+test('Project View', async ({ page }) => {
+  // Use a mock response for issues
+  await page.route('https://api.github.com/repos/chatelao/AI-Dashboard/issues?state=all&per_page=100&page=1', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          number: 101,
+          title: 'Open Issue',
+          state: 'open',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/101',
+          body: 'Some body',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
+          assignee: null,
+          labels: [],
+          updated_at: new Date().toISOString(),
+        },
+        {
+          id: 2,
+          number: 102,
+          title: 'Closed Issue',
+          state: 'closed',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/102',
+          body: 'Some body',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
+          assignee: null,
+          labels: [],
+          updated_at: new Date().toISOString(),
+        }
+      ]),
+    });
+  });
+
+  // Mock pulls to avoid errors
+  await page.route('https://api.github.com/repos/chatelao/AI-Dashboard/pulls?state=all&per_page=100', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.goto('http://localhost:5173/AI-Dashboard/?test=true');
+
+  // Switch to Projects view
+  const projectsButton = page.getByRole('button', { name: 'Projects' });
+  await projectsButton.click();
+
+  // Verify project name is visible
+  await expect(page.locator('.project-name')).toContainText('AI-Dashboard');
+
+  // Verify squares are present
+  const squares = page.locator('.status-square');
+  await expect(squares).toHaveCount(2);
+
+  // Check colors
+  await expect(squares.first()).toHaveClass(/green/);
+  await expect(squares.nth(1)).toHaveClass(/purple/);
+
+  // Take a screenshot
+  await page.screenshot({ path: 'project-view.png' });
+});


### PR DESCRIPTION
This PR adds a second "Projects" page to the dashboard. This view groups issues and PRs by project (repository), displaying one line per project. Behind each project name, tasks are represented by color-coded squares:
- Green: Created/finished tasks.
- Yellow: In-progress tasks.
- Red: Failed tasks.
- Purple: Closed tasks (showing at most the 3 most recent).

Clicking a square navigates directly to the corresponding Jules or GitHub page. The view mode is persisted in local storage.

Fixes #229

---
*PR created automatically by Jules for task [13146390785399174499](https://jules.google.com/task/13146390785399174499) started by @chatelao*