### PR TITLE
Improve Projects view and tooltip layout on mobile

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -528,6 +528,40 @@ a:hover {
   .btn-action {
     margin-top: 4px;
   }
+
+  .project-view {
+    padding: 1rem;
+  }
+
+  .project-line {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .project-name {
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
+
+  .tooltip .tooltip-text {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .tooltip .tooltip-text::after {
+    left: 50%;
+  }
+
+  .issue-title-line .tooltip .tooltip-text,
+  .subtitle .tooltip .tooltip-text {
+    left: -20px;
+    transform: none;
+  }
+
+  .issue-title-line .tooltip .tooltip-text::after,
+  .subtitle .tooltip .tooltip-text::after {
+    left: 30px;
+  }
 }
 
 .btn-duplicate {
@@ -622,13 +656,18 @@ a:hover {
 
 @media (max-width: 600px) {
   .tooltip .tooltip-text {
-    max-width: 300px;
+    max-width: 80vw;
   }
 }
 
 @media (max-width: 400px) {
   .tooltip .tooltip-text {
-    max-width: 200px;
+    max-width: 85vw;
+  }
+
+  .issue-title-line .tooltip .tooltip-text,
+  .subtitle .tooltip .tooltip-text {
+    max-width: 65vw;
   }
 }
 


### PR DESCRIPTION
This change improves the mobile responsiveness of the AI Dashboard, specifically the Projects view and tooltips. On screens narrower than 768px, the Projects view now stacks repository names and status squares vertically. Tooltips for status squares are now centered and have responsive max-widths to prevent them from being cut off at the edge of the screen. Tooltips in the list view have also been adjusted to ensure they remain within the viewport while maintaining their relative positioning. All changes have been verified using Playwright tests across different viewport sizes.

Fixes #241

---
*PR created automatically by Jules for task [6355424928920816055](https://jules.google.com/task/6355424928920816055) started by @chatelao*