### PR TITLE
Update Status Color Logic: Blue for Started, Green for Finished PRs

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -295,12 +295,11 @@ a:hover {
   color: white;
 }
 
-.jules-status-researching, .jules-status-planning { background-color: #0366d6; color: white; }
+.jules-status-researching, .jules-status-planning, .jules-status-awaiting-plan-approval, .jules-status-awaiting-user-feedback { background-color: #0366d6; color: white; }
 .jules-status-coding, .jules-status-in-progress { background-color: #f1e05a; color: black; }
 .jules-status-testing { background-color: #f66a0a; color: white; }
 .jules-status-completed { background-color: #28a745; color: white; }
 .jules-status-queued { background-color: #6a737d; color: white; }
-.jules-status-awaiting-plan-approval, .jules-status-awaiting-user-feedback { background-color: #d29922; color: white; }
 .jules-status-paused { background-color: #8b949e; color: white; }
 .jules-status-failed { background-color: #f85149; color: white; }
 
@@ -804,6 +803,7 @@ a:hover {
 
 .status-square.green { background-color: #238636; }
 .status-square.yellow { background-color: #d29922; }
+.status-square.blue { background-color: #0366d6; }
 .status-square.red { background-color: #f85149; }
 .status-square.purple { background-color: #8957e5; }
 .status-square.grey { background-color: #8b949e; }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -152,7 +152,7 @@ function App() {
     return status === 'in-progress' ? 'InProgress' : status.replace(/-/g, ' ');
   };
 
-  const getIssueStatusColor = (issue: IssueWithJulesStatus): 'purple' | 'red' | 'yellow' | 'green' | 'grey' => {
+  const getIssueStatusColor = (issue: IssueWithJulesStatus): 'purple' | 'red' | 'yellow' | 'blue' | 'green' | 'grey' => {
     if (issue.state === 'closed') return 'purple';
 
     const julesStatus = issue.julesStatus;
@@ -168,20 +168,25 @@ function App() {
     }
 
     if (
-      allJulesStatuses.some(s => ['in-progress', 'researching', 'planning', 'coding', 'testing'].includes(s)) ||
+      allJulesStatuses.some(s => ['in-progress', 'coding', 'testing'].includes(s)) ||
       allPRStatuses.some(ps => ps?.color === 'yellow')
     ) {
       return 'yellow';
     }
 
-    const hasPR = !!issue.pull_request || linkedPRs.length > 0;
-    const hasJules = allJulesStatuses.length > 0;
-
-    if (!hasPR && !hasJules) {
-      return 'grey';
+    if (
+      allJulesStatuses.some(s => ['researching', 'planning', 'awaiting-plan-approval', 'awaiting-user-feedback'].includes(s))
+    ) {
+      return 'blue';
     }
 
-    return 'green';
+    const hasFinishedPR = allPRStatuses.some(ps => ps?.color === 'green' || ps?.color === 'black');
+
+    if (hasFinishedPR) {
+      return 'green';
+    }
+
+    return 'grey';
   };
 
   const getIssueStatusUrl = (issue: IssueWithJulesStatus) => {


### PR DESCRIPTION
I have updated the dashboard's status color logic to better distinguish between preliminary task phases and completed work. 

Key changes include:
- **New Blue Status**: Introduced a 'blue' color (#0366d6) for tasks in 'researching', 'planning', 'awaiting-plan-approval', or 'awaiting-user-feedback' states.
- **Strict Green Status**: Reserved the 'green' color (#238636) exclusively for issues that have an associated Pull Request in a finished or ready state (PR check status color 'green' or 'black').
- **Unified Visuals**: Updated the CSS to include the new blue status square and ensured that Jules status badges for preliminary phases use the same blue color for consistency.
- **Improved Logic Precedence**: Refined the `getIssueStatusColor` function in `App.tsx` to follow a clear priority: Closed/Failed > In Progress (Yellow) > Started (Blue) > Finished (Green) > Default (Grey).

All existing tests pass, and frontend changes have been verified through automated screenshots and video recordings.

Fixes #249

---
*PR created automatically by Jules for task [8469699184137784191](https://jules.google.com/task/8469699184137784191) started by @chatelao*