### PR TITLE
Link finished (purple) issues to GH PR page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -191,7 +191,7 @@ function App() {
 
   const getIssueStatusUrl = (issue: IssueWithJulesStatus) => {
     const color = getIssueStatusColor(issue);
-    if (color === 'green') {
+    if (color === 'green' || color === 'purple') {
       return issue.pull_request?.html_url || issue.linkedPRs?.[0]?.html_url || issue.julesUrl || issue.html_url;
     }
     return issue.julesUrl || issue.html_url;

--- a/web/tests/status_links.spec.ts
+++ b/web/tests/status_links.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test';
 
 test('Status Square Links', async ({ page }) => {
-  // Mock issues: one with PR (will be green), one with Jules (will be yellow)
+  // Mock issues:
+  // 1. Open PR (will be green)
+  // 2. Open Issue (will be yellow)
+  // 3. Closed PR (will be purple)
   await page.route('**/repos/chatelao/AI-Dashboard/issues?state=all&per_page=100&page=1', async route => {
     await route.fulfill({
       status: 200,
@@ -10,7 +13,7 @@ test('Status Square Links', async ({ page }) => {
         {
           id: 1,
           number: 101,
-          title: 'Green Issue',
+          title: 'Green PR',
           state: 'open',
           html_url: 'https://github.com/chatelao/AI-Dashboard/issues/101',
           body: 'Some body',
@@ -34,6 +37,22 @@ test('Status Square Links', async ({ page }) => {
           assignee: { login: 'jules' },
           labels: [{ name: 'jules' }],
           updated_at: new Date().toISOString()
+        },
+        {
+          id: 3,
+          number: 103,
+          title: 'Purple PR',
+          state: 'closed',
+          html_url: 'https://github.com/chatelao/AI-Dashboard/issues/103',
+          body: 'Some body',
+          repository: { full_name: 'chatelao/AI-Dashboard' },
+          assignee: { login: 'jules' },
+          labels: [{ name: 'jules' }],
+          updated_at: new Date().toISOString(),
+          pull_request: {
+            url: 'https://api.github.com/repos/chatelao/AI-Dashboard/pulls/103',
+            html_url: 'https://github.com/chatelao/AI-Dashboard/pull/103'
+          }
         }
       ]),
     });
@@ -45,6 +64,9 @@ test('Status Square Links', async ({ page }) => {
   });
   await page.route('**/repos/chatelao/AI-Dashboard/issues/102/comments?per_page=100', async route => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ user: { login: 'jules' }, body: 'on it! https://jules.google.com/sessions/s2' }]) });
+  });
+  await page.route('**/repos/chatelao/AI-Dashboard/issues/103/comments?per_page=100', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ user: { login: 'jules' }, body: 'on it! https://jules.google.com/sessions/s3' }]) });
   });
 
   // Mock Jules API
@@ -62,8 +84,15 @@ test('Status Square Links', async ({ page }) => {
       body: JSON.stringify({ state: 'STATE_IN_PROGRESS', url: 'https://jules.google.com/sessions/s2', title: 'Working' }),
     });
   });
+  await page.route('**/sessions/s3', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ state: 'STATE_COMPLETED', url: 'https://jules.google.com/sessions/s3', title: 'Finished' }),
+    });
+  });
 
-  // Mock PR detail for green status
+  // Mock PR detail
   await page.route('**/repos/chatelao/AI-Dashboard/pulls/101', async route => {
     await route.fulfill({
       status: 200,
@@ -71,9 +100,23 @@ test('Status Square Links', async ({ page }) => {
       body: JSON.stringify({ head: { sha: 'sha101' }, html_url: 'https://github.com/chatelao/AI-Dashboard/pull/101' }),
     });
   });
+  await page.route('**/repos/chatelao/AI-Dashboard/pulls/103', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ head: { sha: 'sha103' }, html_url: 'https://github.com/chatelao/AI-Dashboard/pull/103' }),
+    });
+  });
 
   // Mock check-runs for green status
   await page.route('**/commits/sha101/check-runs', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total_count: 1, check_runs: [{ status: 'completed', conclusion: 'success' }] }),
+    });
+  });
+  await page.route('**/commits/sha103/check-runs', async route => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -98,9 +141,11 @@ test('Status Square Links', async ({ page }) => {
   // Wait for enrichment
   const greenSquare = page.locator('.status-square.green');
   const yellowSquare = page.locator('.status-square.yellow');
+  const purpleSquare = page.locator('.status-square.purple');
 
   await expect(greenSquare).toBeVisible({ timeout: 10000 });
   await expect(yellowSquare).toBeVisible({ timeout: 10000 });
+  await expect(purpleSquare).toBeVisible({ timeout: 10000 });
 
   // Verify links
   // Green should link to PR
@@ -108,4 +153,7 @@ test('Status Square Links', async ({ page }) => {
 
   // Yellow should link to Jules
   await expect(yellowSquare).toHaveAttribute('href', 'https://jules.google.com/sessions/s2');
+
+  // Purple should link to PR (newly added behavior)
+  await expect(purpleSquare).toHaveAttribute('href', 'https://github.com/chatelao/AI-Dashboard/pull/103');
 });


### PR DESCRIPTION
The dashboard now links finished (purple) issues directly to their corresponding GitHub Pull Request page instead of the Jules session. This was achieved by updating the `getIssueStatusUrl` logic in `web/src/App.tsx` to include 'purple' in the priority list for PR links. I also added a test case to `web/tests/status_links.spec.ts` to ensure this behavior is preserved.

Fixes #251

---
*PR created automatically by Jules for task [811772704814794993](https://jules.google.com/task/811772704814794993) started by @chatelao*