### PR TITLE
Hierarchical Roadmap Progress Dots

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -811,9 +811,26 @@ a:hover {
 .project-roadmap {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 8px 12px;
   margin-top: 4px;
   width: 100%;
+  align-items: center;
+}
+
+.roadmap-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.roadmap-subtasks {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 2px 6px;
+  background: rgba(48, 54, 61, 0.2);
+  margin: 0 2px;
 }
 
 .roadmap-circle {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ interface PRStatus {
 interface RoadmapTask {
   completed: boolean;
   title: string;
+  children?: RoadmapTask[];
 }
 
 interface IssueWithJulesStatus extends GitHubIssue {
@@ -345,6 +346,22 @@ function App() {
     );
   };
 
+  const renderRoadmapTasks = (tasks: RoadmapTask[]) => {
+    return tasks.map((task, idx) => (
+      <div key={idx} className="roadmap-item">
+        <span className="tooltip">
+          <span className={`roadmap-circle ${task.completed ? 'completed' : ''}`}></span>
+          <span className="tooltip-text">{task.title}</span>
+        </span>
+        {task.children && task.children.length > 0 && (
+          <div className="roadmap-subtasks">
+            {renderRoadmapTasks(task.children)}
+          </div>
+        )}
+      </div>
+    ));
+  };
+
   const renderPRNumberTooltip = (item: IssueWithJulesStatus, includeLabel: boolean = true) => {
     return (
       <span className="tooltip">
@@ -393,15 +410,30 @@ function App() {
           const content = new TextDecoder().decode(bytes);
 
           const lines = content.split('\n');
+          const fileRootTasks: RoadmapTask[] = [];
+          const stack: { indent: number, tasks: RoadmapTask[] }[] = [
+            { indent: -1, tasks: fileRootTasks }
+          ];
+
           lines.forEach(line => {
-            const match = line.match(/^\s*-\s*\[([ xX])\]\s*(.*)$/);
+            const match = line.match(/^(\s*)-\s*\[([ xX])\]\s*(.*)$/);
             if (match) {
-              allTasks.push({
-                completed: match[1].toLowerCase() === 'x',
-                title: match[2].trim()
-              });
+              const indent = match[1].length;
+              const completed = match[2].toLowerCase() === 'x';
+              const title = match[3].trim();
+              const newTask: RoadmapTask = { completed, title, children: [] };
+
+              while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+                stack.pop();
+              }
+
+              stack[stack.length - 1].tasks.push(newTask);
+              stack.push({ indent, tasks: newTask.children! });
             }
           });
+          // Only push tasks that actually have something (remove empty children arrays before pushing if desired,
+          // but keeping them is fine for the recursive renderer)
+          allTasks.push(...fileRootTasks);
         } catch (err) {
           console.error(`Error fetching/parsing roadmap file ${file.path} for ${repo}:`, err);
         }
@@ -1251,12 +1283,7 @@ function App() {
                     </div>
                     {roadmapTasks.length > 0 && (
                       <div className="project-roadmap">
-                        {roadmapTasks.map((task, idx) => (
-                          <span key={idx} className="tooltip">
-                            <span className={`roadmap-circle ${task.completed ? 'completed' : ''}`}></span>
-                            <span className="tooltip-text">{task.title}</span>
-                          </span>
-                        ))}
+                        {renderRoadmapTasks(roadmapTasks)}
                       </div>
                     )}
                   </div>

--- a/web/tests/roadmap_progress.spec.ts
+++ b/web/tests/roadmap_progress.spec.ts
@@ -45,9 +45,9 @@ test('Roadmap Progress Circles', async ({ page }) => {
     });
   });
 
-  // Mock ROADMAP.md content
+  // Mock ROADMAP.md content with hierarchy
   await page.route(`https://api.github.com/repos/${repo}/contents/ROADMAP.md?ref=main`, async route => {
-    const content = btoa("- [x] Task 1\n- [ ] Task 2\n- [x] Task 3");
+    const content = btoa("- [x] Task 1\n  - [ ] Subtask 1.1\n  - [x] Subtask 1.2\n- [ ] Task 2");
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -71,18 +71,20 @@ test('Roadmap Progress Circles', async ({ page }) => {
   await expect(roadmapContainer).toBeVisible();
 
   const circles = roadmapContainer.locator('.roadmap-circle');
-  await expect(circles).toHaveCount(3);
+  await expect(circles).toHaveCount(4);
 
-  // Check completed status
-  await expect(circles.nth(0)).toHaveClass(/completed/);
-  await expect(circles.nth(1)).not.toHaveClass(/completed/);
-  await expect(circles.nth(2)).toHaveClass(/completed/);
+  // Verify hierarchy in DOM
+  const subtasks = roadmapContainer.locator('.roadmap-subtasks');
+  await expect(subtasks).toHaveCount(1);
+  const subtaskCircles = subtasks.locator('.roadmap-circle');
+  await expect(subtaskCircles).toHaveCount(2);
 
-  // Check tooltips
+  // Check tooltips to confirm structure
   const roadmapTooltips = roadmapContainer.locator('.tooltip');
   await expect(roadmapTooltips.nth(0).locator('.tooltip-text')).toHaveText('Task 1', { ArrayAttribute: 'hidden' });
-  await expect(roadmapTooltips.nth(1).locator('.tooltip-text')).toHaveText('Task 2', { ArrayAttribute: 'hidden' });
-  await expect(roadmapTooltips.nth(2).locator('.tooltip-text')).toHaveText('Task 3', { ArrayAttribute: 'hidden' });
+  await expect(roadmapTooltips.nth(1).locator('.tooltip-text')).toHaveText('Subtask 1.1', { ArrayAttribute: 'hidden' });
+  await expect(roadmapTooltips.nth(2).locator('.tooltip-text')).toHaveText('Subtask 1.2', { ArrayAttribute: 'hidden' });
+  await expect(roadmapTooltips.nth(3).locator('.tooltip-text')).toHaveText('Task 2', { ArrayAttribute: 'hidden' });
 
   // Take a screenshot
   await page.screenshot({ path: 'roadmap-progress.png' });


### PR DESCRIPTION
This change implements a hierarchical visualization for roadmap progress dots in the Projects view. It includes an updated parsing logic for markdown checklist items that respects indentation to build a task tree, recursive rendering of these tasks, and new CSS styles to visually group subtasks within pill-like containers. Existing Playwright tests were updated and new assertions were added to verify the hierarchical DOM structure and visual appearance.

Fixes #257

---
*PR created automatically by Jules for task [15869486094575543959](https://jules.google.com/task/15869486094575543959) started by @chatelao*