### PR TITLE
Add pink border to status tags for Auto-Repeat issues

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -285,6 +285,10 @@ a:hover {
   text-transform: capitalize;
 }
 
+.auto-repeat-tag {
+  border: 2px solid #e82dce !important;
+}
+
 .state-open {
   background-color: #238636;
   color: white;
@@ -325,6 +329,11 @@ a:hover {
 .pr-label {
   font-size: 0.9rem;
   font-weight: 500;
+}
+
+.pr-label.auto-repeat-tag {
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
 .pr-label-black { color: #8b949e; }
@@ -793,6 +802,10 @@ a:hover {
   align-items: center;
   justify-content: center;
   transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.status-square.auto-repeat-tag {
+  box-sizing: border-box;
 }
 
 .status-square:hover {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -165,6 +165,10 @@ function App() {
     return status === 'in-progress' ? 'InProgress' : status.replace(/-/g, ' ');
   };
 
+  const hasAutoRepeatLabel = (issue: IssueWithJulesStatus) => {
+    return issue.labels.some(l => l.name.toLowerCase() === 'auto-repeat');
+  };
+
   const getIssueStatusColor = (issue: IssueWithJulesStatus): 'purple' | 'red' | 'yellow' | 'blue' | 'green' | 'grey' => {
     if (issue.state === 'closed') return 'purple';
 
@@ -1264,7 +1268,7 @@ function App() {
                             href={getIssueStatusUrl(issue)}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className={`status-square ${getIssueStatusColor(issue)}`}
+                            className={`status-square ${getIssueStatusColor(issue)}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}
                           ></a>
                           <span className="tooltip-text">
                             <strong>#{issue.number}: {issue.title}</strong>
@@ -1361,7 +1365,7 @@ function App() {
                       </div>
                     </td>
                     <td data-label="State">
-                      <span className={`badge state-${issue.state}`}>
+                      <span className={`badge state-${issue.state}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                         {issue.state}
                       </span>
                     </td>
@@ -1374,7 +1378,7 @@ function App() {
                         )}
                         {issue.prStatus && (
                           <div className="pr-status-container">
-                            <span className={`pr-label pr-label-${issue.prStatus.color}`}>
+                            <span className={`pr-label pr-label-${issue.prStatus.color}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                               {issue.prStatus.label}
                             </span>
                             {ghToken && issue.mergeable_state === 'behind' && (
@@ -1404,7 +1408,7 @@ function App() {
                             </div>
                           ) : pr.prStatus && (
                             <div key={pr.id} className="pr-status-container subtitle">
-                              <span className={`pr-label pr-label-${pr.prStatus.color}`}>
+                              <span className={`pr-label pr-label-${pr.prStatus.color}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                                 {pr.prStatus.label}
                               </span>
                               {ghToken && pr.mergeable_state === 'behind' && (
@@ -1441,12 +1445,12 @@ function App() {
                         {issue.julesStatus ? (
                           issue.julesUrl ? (
                             <a href={issue.julesUrl} target="_blank" rel="noopener noreferrer">
-                              <span className={`badge jules-status-${issue.julesStatus}`}>
+                              <span className={`badge jules-status-${issue.julesStatus}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                                 {formatJulesStatus(issue.julesStatus)}
                               </span>
                             </a>
                           ) : (
-                            <span className={`badge jules-status-${issue.julesStatus}`}>
+                            <span className={`badge jules-status-${issue.julesStatus}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                               {formatJulesStatus(issue.julesStatus)}
                             </span>
                           )
@@ -1468,12 +1472,12 @@ function App() {
                             <div key={pr.id} className="subtitle">
                               {pr.julesUrl ? (
                                 <a href={pr.julesUrl} target="_blank" rel="noopener noreferrer">
-                                  <span className={`badge jules-status-${pr.julesStatus}`}>
+                                  <span className={`badge jules-status-${pr.julesStatus}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                                     {formatJulesStatus(pr.julesStatus)}
                                   </span>
                                 </a>
                               ) : (
-                                <span className={`badge jules-status-${pr.julesStatus}`}>
+                                <span className={`badge jules-status-${pr.julesStatus}${hasAutoRepeatLabel(issue) ? ' auto-repeat-tag' : ''}`}>
                                   {formatJulesStatus(pr.julesStatus)}
                                 </span>
                               )}


### PR DESCRIPTION
This change adds a distinctive pink (#e82dce) border to all status indicators for GitHub issues labeled with "Auto-Repeat".

Changes:
- **web/src/App.tsx**: Added logic to detect the "Auto-Repeat" label and conditionally apply a new CSS class to status badges (State, Jules) and labels (PR) in the List view, as well as status squares in the Projects view.
- **web/src/App.css**: Defined the `.auto-repeat-tag` class and adjusted layout properties (like `box-sizing` and `padding`) to ensure the border is displayed correctly without breaking the UI layout.

Verification:
- Added and ran a Playwright test to confirm the class is applied correctly based on the label.
- Manually verified via screenshots that the border appears as expected in both List and Projects views.
- Confirmed that the application build remains functional.

Fixes #261

---
*PR created automatically by Jules for task [4626201217003907285](https://jules.google.com/task/4626201217003907285) started by @chatelao*